### PR TITLE
feat/26

### DIFF
--- a/src/main/java/com/picnee/travel/api/PostCommentController.java
+++ b/src/main/java/com/picnee/travel/api/PostCommentController.java
@@ -60,5 +60,15 @@ public class PostCommentController implements PostCommentApi {
         List<GetPostCommentRes> commentRes = postCommentService.getComments(postId, auth);
         return ResponseEntity.status(OK).body(commentRes);
     }
+
+    @PostMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<String> createChildrenComment(@PathVariable("postId") UUID postId,
+                                                        @PathVariable("commentId") UUID commentId,
+                                                        @Valid @RequestBody CreatePostCommentReq dto,
+                                                        @AuthenticatedUser AuthenticatedUserReq auth) {
+        PostComment childrenComment = postCommentService.createChildrenComment(postId, commentId, dto, auth);
+
+        return ResponseEntity.status(OK).body(childrenComment.getId().toString());
+    }
 }
 

--- a/src/main/java/com/picnee/travel/api/in/PostCommentApi.java
+++ b/src/main/java/com/picnee/travel/api/in/PostCommentApi.java
@@ -6,6 +6,7 @@ import com.picnee.travel.domain.postComment.dto.res.GetPostCommentRes;
 import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
@@ -27,4 +28,7 @@ public interface PostCommentApi {
 
     @Operation(summary = "댓글 조회", description = "댓글을 조회한다.")
     public ResponseEntity<List<GetPostCommentRes>> getPostComment(UUID postId, AuthenticatedUserReq auth);
+
+    @Operation(summary = "대댓글 생성", description = "대댓글을 생성한다.")
+    public ResponseEntity<String> createChildrenComment(UUID postId, UUID commentId, CreatePostCommentReq dto, AuthenticatedUserReq auth);
 }

--- a/src/main/java/com/picnee/travel/domain/post/entity/Post.java
+++ b/src/main/java/com/picnee/travel/domain/post/entity/Post.java
@@ -6,6 +6,7 @@ import com.picnee.travel.domain.post.dto.req.ModifyPostReq;
 import com.picnee.travel.domain.postComment.entity.PostComment;
 import com.picnee.travel.domain.user.entity.User;
 import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Table;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -51,7 +52,7 @@ public class Post extends SoftDeleteBaseEntity {
     @JoinColumn(name = "board_id")
     private Board board;
     @Builder.Default
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<PostComment> comments = new ArrayList<>();
 
 

--- a/src/main/java/com/picnee/travel/domain/post/service/PostService.java
+++ b/src/main/java/com/picnee/travel/domain/post/service/PostService.java
@@ -9,7 +9,6 @@ import com.picnee.travel.domain.post.entity.Post;
 import com.picnee.travel.domain.post.exception.NotFoundPostException;
 import com.picnee.travel.domain.post.exception.NotPostAuthorException;
 import com.picnee.travel.domain.post.repository.PostRepository;
-import com.picnee.travel.domain.postComment.service.PostCommentService;
 import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
 import com.picnee.travel.domain.user.entity.User;
 import com.picnee.travel.domain.user.service.UserService;

--- a/src/main/java/com/picnee/travel/domain/postComment/dto/req/CreatePostCommentReq.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/dto/req/CreatePostCommentReq.java
@@ -30,11 +30,11 @@ public class CreatePostCommentReq {
                 .build();
     }
 
-    //TODO : 대댓글
-    public static PostComment toEntityCoComment(CreatePostCommentReq dto, User user, Post post) {
+    public static PostComment toEntityCoComment(Post post, PostComment postComment, User user, CreatePostCommentReq dto) {
         return PostComment.builder()
                 .user(user)
                 .content(dto.content)
+                .commentParent(postComment)
                 .post(post)
                 .build();
     }

--- a/src/main/java/com/picnee/travel/domain/postComment/dto/res/GetChildrenCommentRes.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/dto/res/GetChildrenCommentRes.java
@@ -1,0 +1,31 @@
+package com.picnee.travel.domain.postComment.dto.res;
+
+import com.picnee.travel.domain.postComment.entity.PostComment;
+import com.picnee.travel.domain.user.dto.res.UserRes;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class GetChildrenCommentRes {
+
+    private String content;
+    private UserRes userRes;
+    private LocalDateTime createdAt;
+
+    public static List<GetChildrenCommentRes> from(List<PostComment> replies) {
+        return replies.stream()
+                .map(reply -> GetChildrenCommentRes.builder()
+                        .content(reply.getContent())
+                        .userRes(UserRes.from(reply.getUser()))
+                        .createdAt(reply.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/picnee/travel/domain/postComment/dto/res/GetPostCommentRes.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/dto/res/GetPostCommentRes.java
@@ -21,6 +21,7 @@ public class GetPostCommentRes {
 
     private String content;
     private UserRes userRes;
+    private List<GetChildrenCommentRes> replies;
     private LocalDateTime createdAt;
 
     public static List<GetPostCommentRes> from(List<PostComment> comments) {
@@ -29,6 +30,7 @@ public class GetPostCommentRes {
                         .content(comment.getContent())
                         .userRes(UserRes.from(comment.getUser()))
                         .createdAt(comment.getCreatedAt())
+                        .replies(GetChildrenCommentRes.from(comment.getChildren()))
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
@@ -18,10 +18,14 @@ public class PostCommentRepositoryImpl implements PostCommentRepositoryCustom{
     @Override
     public List<PostComment> findByCommentsOfPost(Post post) {
         QPostComment postComment = QPostComment.postComment;
+        QPostComment childComment = new QPostComment("childComment");
 
         return jpaQueryFactory.selectFrom(postComment)
-                .where(postComment.post.eq(post).
-                        and(postComment.isDeleted.isFalse()))
+                .leftJoin(postComment.children, childComment).fetchJoin()  // Fetch replies (nested comments)
+                .where(postComment.post.eq(post)
+                        .and(postComment.isDeleted.isFalse())
+                        .and(postComment.commentParent.isNull()))  // Fetch only parent comments
+                .orderBy(postComment.createdAt.desc())  // Optional: order by creation time
                 .fetch();
     }
 }

--- a/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
@@ -21,11 +21,11 @@ public class PostCommentRepositoryImpl implements PostCommentRepositoryCustom{
         QPostComment childComment = new QPostComment("childComment");
 
         return jpaQueryFactory.selectFrom(postComment)
-                .leftJoin(postComment.children, childComment).fetchJoin()  // Fetch replies (nested comments)
+                .leftJoin(postComment.children, childComment).fetchJoin()
                 .where(postComment.post.eq(post)
                         .and(postComment.isDeleted.isFalse())
-                        .and(postComment.commentParent.isNull()))  // Fetch only parent comments
-                .orderBy(postComment.createdAt.desc())  // Optional: order by creation time
+                        .and(postComment.commentParent.isNull()))
+                .orderBy(postComment.createdAt.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
@@ -86,6 +86,18 @@ public class PostCommentService {
     }
 
     /**
+     * 대댓글 생성
+     */
+    @Transactional
+    public PostComment createChildrenComment(UUID postId, UUID commentId, CreatePostCommentReq dto, AuthenticatedUserReq auth) {
+        Post post = postService.findByIdNotDeletedPost(postId);
+        PostComment postComment = findByIdNotDeletedPostComment(commentId);
+        User user = userService.findByEmail(auth.getEmail());
+
+        return postCommentRepository.save(CreatePostCommentReq.toEntityCoComment(post, postComment, user, dto));
+    }
+
+    /**
      * 댓글 주인인지 확인
      */
     private void validOwner(PostComment postComment, User user) {


### PR DESCRIPTION
### ✨ 작업 내용

- [x] 대댓글 생성
- [x] 댓글 조회 (대댓글 포함)
- [x] 게시글 및 부모 댓글 삭제 시 연쇄 삭제(cascade)

### ✨ 코멘트

- 댓글에 cascade 설정

```java
@Builder.Default
    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST, orphanRemoval = true)
    private List<PostComment> comments = new ArrayList<>();
```

cascade 설정을 통해 게시글이 hardDelete 될 경우 연관관계 걸린 댓글들을 삭제시켜줄려고 합니다.

### Git Close

- close #26 
