### PR TITLE
feat/31

### DIFF
--- a/src/main/java/com/picnee/travel/api/UserController.java
+++ b/src/main/java/com/picnee/travel/api/UserController.java
@@ -4,6 +4,8 @@ import com.picnee.travel.api.in.UserApi;
 import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
 import com.picnee.travel.domain.user.dto.req.CreateUserReq;
 import com.picnee.travel.domain.user.dto.req.LoginUserReq;
+import com.picnee.travel.domain.user.dto.req.UpdateUserNicknameReq;
+import com.picnee.travel.domain.user.entity.User;
 import com.picnee.travel.domain.user.service.UserService;
 import com.picnee.travel.global.jwt.dto.res.AccessTokenRes;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
@@ -44,6 +46,13 @@ public class UserController implements UserApi {
                                                           @RequestHeader("RefreshToken") String refreshToken) {
         AccessTokenRes res = userService.reissueToken(auth, refreshToken);
         return ResponseEntity.status(OK).body(res);
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<String> updateNickname(@AuthenticatedUser AuthenticatedUserReq auth,
+                                               @Valid @RequestBody UpdateUserNicknameReq dto) {
+        User user = userService.updateNickname(auth, dto.getNickname());
+        return ResponseEntity.status(OK).body(user.getNickname());
     }
 }
 

--- a/src/main/java/com/picnee/travel/api/in/UserApi.java
+++ b/src/main/java/com/picnee/travel/api/in/UserApi.java
@@ -3,6 +3,7 @@ package com.picnee.travel.api.in;
 import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
 import com.picnee.travel.domain.user.dto.req.CreateUserReq;
 import com.picnee.travel.domain.user.dto.req.LoginUserReq;
+import com.picnee.travel.domain.user.dto.req.UpdateUserNicknameReq;
 import com.picnee.travel.global.jwt.dto.res.AccessTokenRes;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,4 +20,7 @@ public interface UserApi {
 
     @Operation(summary = "토큰 재발급", description = "accessToken을 재발급 한다.")
     public ResponseEntity<AccessTokenRes> reGenerateToken(AuthenticatedUserReq auth, String refreshToken);
+
+    @Operation(summary = "닉네임 설정", description = "OAuth 로그인 한 사람 중 닉네임을 설정하지 않은 사용자의 닉네임을 설정하게 한다.")
+    public ResponseEntity<String> updateNickname(AuthenticatedUserReq auth, UpdateUserNicknameReq dto);
 }

--- a/src/main/java/com/picnee/travel/domain/user/dto/req/CreateUserReq.java
+++ b/src/main/java/com/picnee/travel/domain/user/dto/req/CreateUserReq.java
@@ -23,7 +23,7 @@ public class CreateUserReq {
     @NotNull(message = "이메일은 필수입니다.")
     private String email;
     @NotNull(message = "닉네임은 필수입니다.")
-    @Pattern(regexp = "^(?=.*[A-Za-z가-힣])[A-Za-z\\d가-힣]{2,8}$", message = "닉네임은 2자 이상 8자 이하이며, 영어와 한글이 반드시 하나 이상은 포함되어야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z가-힣])[A-Za-z\\d가-힣]{2,20}$", message = "닉네임은 2자 이상 20자 이하이며, 영어와 한글이 반드시 하나 이상은 포함되어야 합니다.")
     private String nickname;
     @NotNull(message = "비밀번호는 필수입니다.")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$", message = "비밀번호는 8자 이상 16자 이하이며, 영문, 숫자, 특수문자로 이루어져야합니다.")

--- a/src/main/java/com/picnee/travel/domain/user/dto/req/UpdateUserNicknameReq.java
+++ b/src/main/java/com/picnee/travel/domain/user/dto/req/UpdateUserNicknameReq.java
@@ -1,0 +1,20 @@
+package com.picnee.travel.domain.user.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+public class UpdateUserNicknameReq {
+    @NotNull(message = "닉네임은 필수입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z가-힣])[A-Za-z\\d가-힣]{2,20}$", message = "닉네임은 2자 이상 20자 이하이며, 영어와 한글이 반드시 하나 이상은 포함되어야 합니다.")
+    private String nickname;
+}

--- a/src/main/java/com/picnee/travel/domain/user/entity/User.java
+++ b/src/main/java/com/picnee/travel/domain/user/entity/User.java
@@ -61,6 +61,8 @@ public class User extends SoftDeleteBaseEntity {
     private Boolean isMarketing;
     @Column(name = "is_alarm")
     private Boolean isAlarm;
+    @Column(name = "is_default_nickname")
+    private boolean isDefaultNickname;
     @Column(name = "role")
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -83,12 +85,4 @@ public class User extends SoftDeleteBaseEntity {
     public void changeNullState() {
         this.state = null;
     }
-
-    public void softDelete() {
-
-    }
-
-    // oauth -> 비밀번호 변경할려면 기존 비밀번호 입력 -> oauth 비밀번호 x -> 구분 값을 넣어줘야함 -> 0 -> 비밀번호 입력없이 바로 설정가능
-    //                                                                             ->
-
 }

--- a/src/main/java/com/picnee/travel/domain/user/entity/User.java
+++ b/src/main/java/com/picnee/travel/domain/user/entity/User.java
@@ -33,8 +33,6 @@ public class User extends SoftDeleteBaseEntity {
     @JdbcTypeCode(SqlTypes.VARCHAR)
     @Column(name = "user_id", columnDefinition = "VARCHAR(36)")
     private UUID id;
-    @Column(name = "username")
-    private String username;
     @Column(name = "password")
     private String password;
     @Column(name = "phone_number")
@@ -89,4 +87,8 @@ public class User extends SoftDeleteBaseEntity {
     public void softDelete() {
 
     }
+
+    // oauth -> 비밀번호 변경할려면 기존 비밀번호 입력 -> oauth 비밀번호 x -> 구분 값을 넣어줘야함 -> 0 -> 비밀번호 입력없이 바로 설정가능
+    //                                                                             ->
+
 }

--- a/src/main/java/com/picnee/travel/domain/user/entity/User.java
+++ b/src/main/java/com/picnee/travel/domain/user/entity/User.java
@@ -85,4 +85,9 @@ public class User extends SoftDeleteBaseEntity {
     public void changeNullState() {
         this.state = null;
     }
+
+    public void changeDefaultNickname(String nickname) {
+        this.nickname = nickname;
+        this.isDefaultNickname = false;
+    }
 }

--- a/src/main/java/com/picnee/travel/domain/user/entity/User.java
+++ b/src/main/java/com/picnee/travel/domain/user/entity/User.java
@@ -78,7 +78,7 @@ public class User extends SoftDeleteBaseEntity {
         this.passwordCount = 0;
     }
 
-    public void changeLockedStatus() {
+    public void updateLockedStatus() {
         this.state = State.LOCKED;
     }
 
@@ -86,7 +86,7 @@ public class User extends SoftDeleteBaseEntity {
         this.state = null;
     }
 
-    public void changeDefaultNickname(String nickname) {
+    public void updateDefaultNickname(String nickname) {
         this.nickname = nickname;
         this.isDefaultNickname = false;
     }

--- a/src/main/java/com/picnee/travel/domain/user/exception/NotProvideOAuthException.java
+++ b/src/main/java/com/picnee/travel/domain/user/exception/NotProvideOAuthException.java
@@ -1,0 +1,10 @@
+package com.picnee.travel.domain.user.exception;
+
+import com.picnee.travel.global.exception.BusinessException;
+import com.picnee.travel.global.exception.ErrorCode;
+
+public class NotProvideOAuthException extends BusinessException {
+    public NotProvideOAuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/picnee/travel/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/picnee/travel/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.UUID;
 public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByEmail(String email);
+
+    Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/picnee/travel/domain/user/service/UserService.java
+++ b/src/main/java/com/picnee/travel/domain/user/service/UserService.java
@@ -47,7 +47,6 @@ public class UserService {
 
         User user = User.builder()
                 .email(dto.getEmail())
-                .username(dto.getUsername())
                 .nickname(dto.getNickname())
                 .password(passwordEncoder.encode(dto.getPassword()))
                 .phoneNumber(phoneNumber)

--- a/src/main/java/com/picnee/travel/domain/user/service/UserService.java
+++ b/src/main/java/com/picnee/travel/domain/user/service/UserService.java
@@ -59,6 +59,7 @@ public class UserService {
                 .profileImage(null)
                 .isMarketing(dto.getIsMarketing())
                 .isAlarm(dto.getIsAlarm())
+                .isDefaultNickname(false)
                 .role(Role.USER)
                 .state(State.ACTIVE)
                 .build();

--- a/src/main/java/com/picnee/travel/domain/user/service/UserService.java
+++ b/src/main/java/com/picnee/travel/domain/user/service/UserService.java
@@ -12,8 +12,6 @@ import com.picnee.travel.global.jwt.dto.res.AccessTokenRes;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
 import com.picnee.travel.global.jwt.provider.TokenProvider;
 import com.picnee.travel.global.redis.service.RedisService;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -89,7 +87,7 @@ public class UserService {
             user.failPasswordCount();
 
             if(user.getPasswordCount() >= 5){
-                user.changeLockedStatus();
+                user.updateLockedStatus();
             }
 
             throw new LoginFailedException(LOGIN_FAILED_EXCEPTION, "비밀번호 " + user.getPasswordCount());
@@ -132,7 +130,7 @@ public class UserService {
             throw new IllegalArgumentException("기존 닉네임과 동일한 닉네임은 사용할 수 없습니다.");
         }
 
-        user.changeDefaultNickname(nickname);
+        user.updateDefaultNickname(nickname);
         return user;
     }
 

--- a/src/main/java/com/picnee/travel/domain/user/service/UserService.java
+++ b/src/main/java/com/picnee/travel/domain/user/service/UserService.java
@@ -12,6 +12,8 @@ import com.picnee.travel.global.jwt.dto.res.AccessTokenRes;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
 import com.picnee.travel.global.jwt.provider.TokenProvider;
 import com.picnee.travel.global.redis.service.RedisService;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -117,6 +119,21 @@ public class UserService {
 
         throw new NotValidRefreshTokenException(NOT_VALID_REFRESH_TOKEN_EXCEPTION);
 
+    }
+
+    /**
+     * 닉네임 설정
+     * */
+    @Transactional
+    public User updateNickname(AuthenticatedUserReq auth, String nickname) {
+        User user = findByEmail(auth.getEmail());
+
+        if(user.getNickname().equals(nickname)){
+            throw new IllegalArgumentException("기존 닉네임과 동일한 닉네임은 사용할 수 없습니다.");
+        }
+
+        user.changeDefaultNickname(nickname);
+        return user;
     }
 
     public User findByEmail(String email) {

--- a/src/main/java/com/picnee/travel/global/exception/ErrorCode.java
+++ b/src/main/java/com/picnee/travel/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     NOT_VALID_REFRESH_TOKEN_EXCEPTION(UNAUTHORIZED, "005", "유효하지 않은 토큰입니다."),
     NOT_VALID_OWNER_EXCEPTION(UNAUTHORIZED, "G006", "작성자만 삭제/수정이 가능합니다."),
     NOT_NOTIFICATION_RECIPIENT_EXCEPTION(UNAUTHORIZED, "G007", "알림 수신자가 아닙니다. 본인의 알림만 읽을 수 있습니다."),
+    NOT_PROVIDE_OAUTH_EXCEPTION(UNAUTHORIZED, "G008", "올바르지 않은 소셜 로그인입니다."),
 
     /**
      * 403

--- a/src/main/java/com/picnee/travel/global/oauth/CustomOauth2UserService.java
+++ b/src/main/java/com/picnee/travel/global/oauth/CustomOauth2UserService.java
@@ -1,6 +1,5 @@
 package com.picnee.travel.global.oauth;
 
-import com.picnee.travel.domain.user.entity.Role;
 import com.picnee.travel.domain.user.entity.User;
 import com.picnee.travel.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -49,8 +48,20 @@ public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequ
             return existEmail.get();
         }
 
+        validAndUpdateNickname(oAuth2User);
+
         User user = oAuth2User.toEntity();
         return userRepository.save(user);
+    }
+
+    private void validAndUpdateNickname(OAuthAttributes oAuth2User) {
+        if (oAuth2User.isOverNickname()) {
+            oAuth2User.updateOverNickname();
+        }
+
+        if (userRepository.existsByNickname(oAuth2User.getNickname())) {
+            oAuth2User.updateDefaultNickname();
+        }
     }
 
     private List<GrantedAuthority> getAuthorities(User user) {

--- a/src/main/java/com/picnee/travel/global/oauth/OAuth2CustomUser.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuth2CustomUser.java
@@ -16,7 +16,7 @@ public class OAuth2CustomUser implements OAuth2User, Serializable {
     private String social;
     private Map<String, Object> attributes;
     private List<GrantedAuthority> authorities;
-    private boolean isNewUser;
+    private boolean isDefaultNickname;
     private OAuthAttributes oAuthAttributes;
 
     @Override
@@ -34,8 +34,8 @@ public class OAuth2CustomUser implements OAuth2User, Serializable {
         return this.email;
     }
 
-    public boolean isNewUser() {
-        return isNewUser;
+    public boolean isDefaultNickname() {
+        return isDefaultNickname;
     }
 
     public OAuthAttributes getOAuthAttributes() {

--- a/src/main/java/com/picnee/travel/global/oauth/OAuth2CustomUser.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuth2CustomUser.java
@@ -1,6 +1,7 @@
 package com.picnee.travel.global.oauth;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
@@ -9,6 +10,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+@Getter
 @AllArgsConstructor
 public class OAuth2CustomUser implements OAuth2User, Serializable {
 
@@ -40,10 +42,6 @@ public class OAuth2CustomUser implements OAuth2User, Serializable {
 
     public OAuthAttributes getOAuthAttributes() {
         return oAuthAttributes;
-    }
-
-    public String getSocial() {
-        return this.social;
     }
 }
 

--- a/src/main/java/com/picnee/travel/global/oauth/OAuth2UserSuccessHandler.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuth2UserSuccessHandler.java
@@ -37,21 +37,6 @@ public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         OAuth2CustomUser oAuth2CustomUser = (OAuth2CustomUser) authentication.getPrincipal();
 
-        // 기존 유저가 아닌 경우 requestBody 값 전달
-        if (oAuth2CustomUser.isNewUser()) {
-            response.setStatus(HttpServletResponse.SC_OK);
-            response.setContentType("application/json;charset=UTF-8");
-
-            Map<String, Object> responseBody = new HashMap<>();
-            responseBody.put("isNewUser", true);
-            responseBody.put("oauthAttributes", oAuth2CustomUser.getOAuthAttributes());
-            responseBody.put("social", oAuth2CustomUser.getSocial());
-
-            response.getWriter().write(objectMapper.writeValueAsString(responseBody));
-            response.sendRedirect("http://localhost:3000/oauth/login");
-            return;
-        }
-
         // 기존 유저인 경우 로그인 성공 응답 처리
         User user = userRepository.findByEmail(oAuth2CustomUser.getName()).orElseThrow(()
                 -> new NotFoundEmailException(NOT_FOUND_EMAIL_EXCEPTION));

--- a/src/main/java/com/picnee/travel/global/oauth/OAuth2UserSuccessHandler.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuth2UserSuccessHandler.java
@@ -41,6 +41,11 @@ public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         User user = userRepository.findByEmail(oAuth2CustomUser.getName()).orElseThrow(()
                 -> new NotFoundEmailException(NOT_FOUND_EMAIL_EXCEPTION));
 
+        if (user.isDefaultNickname()) {
+            getRedirectStrategy().sendRedirect(request, response, "/nickname");
+            return;
+        }
+
         String accessToken = tokenProvider.generateAccessToken(authentication);
         String refreshToken = tokenProvider.generateRefreshToken(authentication);
 

--- a/src/main/java/com/picnee/travel/global/oauth/OAuth2UserSuccessHandler.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuth2UserSuccessHandler.java
@@ -44,9 +44,6 @@ public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         String accessToken = tokenProvider.generateAccessToken(authentication);
         String refreshToken = tokenProvider.generateRefreshToken(authentication);
 
-        log.info("AccessToekn = {}", accessToken);
-        log.info("RefreshToken = {}", refreshToken);
-
         JwtTokenRes jwtTokenRes = JwtTokenRes.from(accessToken, refreshToken, user);
         redisService.saveValue(user.getEmail(), jwtTokenRes.getRefreshToken());
 
@@ -64,6 +61,7 @@ public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHand
 
     private void createResponseHandler(HttpServletResponse response, JwtTokenRes jwtTokenRes) throws IOException {
         response.addHeader(JwtFilter.ACCESS_AUTHORIZATION_HEADER, "Bearer " + jwtTokenRes.getAccessToken());
+        response.addHeader(JwtFilter.REFRESH_AUTHORIZATION_HEADER, "Bearer " + jwtTokenRes.getRefreshToken());
         response.getWriter().write(objectMapper.writeValueAsString(jwtTokenRes));
     }
 }

--- a/src/main/java/com/picnee/travel/global/oauth/OAuthAttributes.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuthAttributes.java
@@ -31,7 +31,7 @@ public class OAuthAttributes {
         OAuthInfo oAuthInfo = OAuthInfo.from(socialName);
 
         String nickname = oAuthInfo.getNickname(attributes);
-        boolean isDefaultNickname = nickname.length() == 21;
+        boolean isDefaultNickname = nickname.length() == 20;
         String email = oAuthInfo.getEmail(attributes);
 
         return OAuthAttributes.builder()

--- a/src/main/java/com/picnee/travel/global/oauth/OAuthAttributes.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuthAttributes.java
@@ -22,64 +22,23 @@ import java.util.UUID;
 public class OAuthAttributes {
 
     private Map<String, Object> attributes = new HashMap<>();
-    private String nameAttributesKey;
     private String email;
     private String nickname;
+    private String socialRoot;
     private boolean isDefaultNickname;
 
     public static OAuthAttributes of(String socialName, Map<String, Object> attributes) {
-        if("kakao".equalsIgnoreCase(socialName)) {
-            return ofKakao("id", attributes);
-        } else if("google".equalsIgnoreCase(socialName)) {
-            return ofGoogle("id", attributes);
-        } else if("naver".equalsIgnoreCase(socialName)) {
-            return ofNaver("response", attributes);
-        }
+        OAuthInfo oAuthInfo = OAuthInfo.from(socialName);
 
-        throw new IllegalArgumentException("잘못된 소셜 정보입니다.");
-    }
-
-    private static OAuthAttributes ofNaver(String response, Map<String, Object> attributes) {
-        Map<String, Object> oauthResponse = (Map<String, Object>) attributes.get("response");
-
-        // TODO 중복 로직 메서드로 만들기
-        boolean isDefaultNickname = oauthResponse.get("nickname") == null;
-        String nickname = isDefaultNickname ? UUID.randomUUID().toString().substring(0, 21) : String.valueOf(oauthResponse.get("nickname"));
+        String nickname = oAuthInfo.getNickname(attributes);
+        boolean isDefaultNickname = nickname.length() == 21;
+        String email = oAuthInfo.getEmail(attributes);
 
         return OAuthAttributes.builder()
                 .nickname(nickname)
-                .email(String.valueOf(oauthResponse.get("email")))
+                .email(email)
                 .attributes(attributes)
-                .nameAttributesKey(response)
-                .isDefaultNickname(isDefaultNickname)
-                .build();
-    }
-
-    private static OAuthAttributes ofGoogle(String id, Map<String, Object> attributes) {
-        boolean isDefaultNickname = attributes.get("name") == null;
-        String nickname = isDefaultNickname? UUID.randomUUID().toString().substring(0, 21) : String.valueOf(attributes.get("name"));
-
-        return OAuthAttributes.builder()
-                .nickname(nickname)
-                .email(String.valueOf(attributes.get("email")))
-                .attributes(attributes)
-                .nameAttributesKey(id)
-                .isDefaultNickname(isDefaultNickname)
-                .build();
-    }
-
-    private static OAuthAttributes ofKakao(String id, Map<String, Object> attributes) {
-        Map<String, Object> response = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
-
-        boolean isDefaultNickname = properties == null || properties.get("nickname") == null;
-        String nickname = isDefaultNickname ? UUID.randomUUID().toString().substring(0, 21) : String.valueOf(properties.get("nickname"));
-
-        return OAuthAttributes.builder()
-                .nickname(nickname)
-                .email(String.valueOf(response.get("email")))
-                .attributes(response)
-                .nameAttributesKey(id)
+                .socialRoot(socialName)
                 .isDefaultNickname(isDefaultNickname)
                 .build();
     }
@@ -91,14 +50,13 @@ public class OAuthAttributes {
                 .password(UUID.randomUUID().toString())
                 .role(Role.USER)
                 .isDefaultNickname(isDefaultNickname)
-//                .socialRoot(dto.getSocial() == null ? null : dto.getSocial()) TODO 어떻게 받아올지 생각하기
+                .socialRoot(socialRoot)
                 .passwordCount(0)
                 .accountLock(false)
                 .lastPasswordExpired(LocalDateTime.now())
                 .profileImage(null)
                 .isMarketing(false)
                 .isAlarm(false)
-                .role(Role.USER)
                 .state(State.ACTIVE)
                 .build();
     }

--- a/src/main/java/com/picnee/travel/global/oauth/OAuthAttributes.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuthAttributes.java
@@ -44,7 +44,7 @@ public class OAuthAttributes {
 
         // TODO 중복 로직 메서드로 만들기
         boolean isDefaultNickname = oauthResponse.get("nickname") == null;
-        String nickname = isDefaultNickname ? "user_" + UUID.randomUUID().toString().substring(0, 11) : String.valueOf(oauthResponse.get("nickname"));
+        String nickname = isDefaultNickname ? UUID.randomUUID().toString().substring(0, 21) : String.valueOf(oauthResponse.get("nickname"));
 
         return OAuthAttributes.builder()
                 .nickname(nickname)
@@ -57,7 +57,7 @@ public class OAuthAttributes {
 
     private static OAuthAttributes ofGoogle(String id, Map<String, Object> attributes) {
         boolean isDefaultNickname = attributes.get("name") == null;
-        String nickname = isDefaultNickname? "user_" + UUID.randomUUID().toString().substring(0, 11) : String.valueOf(attributes.get("name"));
+        String nickname = isDefaultNickname? UUID.randomUUID().toString().substring(0, 21) : String.valueOf(attributes.get("name"));
 
         return OAuthAttributes.builder()
                 .nickname(nickname)
@@ -73,7 +73,7 @@ public class OAuthAttributes {
         Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
 
         boolean isDefaultNickname = properties == null || properties.get("nickname") == null;
-        String nickname = isDefaultNickname ? "user_" + UUID.randomUUID().toString().substring(0, 11) : String.valueOf(properties.get("nickname"));
+        String nickname = isDefaultNickname ? UUID.randomUUID().toString().substring(0, 21) : String.valueOf(properties.get("nickname"));
 
         return OAuthAttributes.builder()
                 .nickname(nickname)

--- a/src/main/java/com/picnee/travel/global/oauth/OAuthAttributes.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuthAttributes.java
@@ -60,5 +60,18 @@ public class OAuthAttributes {
                 .state(State.ACTIVE)
                 .build();
     }
+
+    public void updateDefaultNickname(){
+        this.nickname = UUID.randomUUID().toString().substring(0, 20);
+        this.isDefaultNickname = true;
+    }
+
+    public void updateOverNickname() {
+        this.nickname = this.nickname.substring(0, 20);
+    }
+
+    public boolean isOverNickname(){
+        return this.nickname.length() > 20;
+    }
 }
 

--- a/src/main/java/com/picnee/travel/global/oauth/OAuthInfo.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuthInfo.java
@@ -25,10 +25,6 @@ public enum OAuthInfo {
     private final String email;
 
     public String getNickname(Map<String, Object> attributes) {
-//        Map<String, Object> primary = getAttributeMap(attributes, mainAttribute);
-//        Map<String, Object> secondary = secondaryAttribute != null ? getAttributeMap(attributes, secondaryAttribute) : primary;
-//        return secondary.get(nickname) != null ? secondary.get(nickname).toString() : UUID.randomUUID().toString().substring(0, 20);
-
         return Optional.ofNullable(secondaryAttribute)
                 .map(attr -> getAttributeMap(attributes, attr))
                 .orElseGet(() -> getAttributeMap(attributes, mainAttribute))
@@ -37,8 +33,6 @@ public enum OAuthInfo {
     }
 
     public String getEmail(Map<String, Object> attributes) {
-//        Map<String, Object> primary = getAttributeMap(attributes, mainAttribute);
-//        return primary.get(email).toString();
         return Optional.ofNullable(getAttributeMap(attributes, mainAttribute))
                 .map(map -> map.get(email))
                 .map(Object::toString)

--- a/src/main/java/com/picnee/travel/global/oauth/OAuthInfo.java
+++ b/src/main/java/com/picnee/travel/global/oauth/OAuthInfo.java
@@ -1,0 +1,43 @@
+package com.picnee.travel.global.oauth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthInfo {
+    KAKAO("kakao_account", "properties", "nickname", "email"),
+    NAVER("response", null, "nickname", "email"),
+    GOOGLE(null, null, "name", "email");
+
+    private final String mainAttributeKey;
+    private final String secondaryAttributeKey;
+    private final String nicknameKey;
+    private final String emailKey;
+
+    public String getNickname(Map<String, Object> attributes) {
+        Map<String, Object> primary = getAttributeMap(attributes, mainAttributeKey);
+        Map<String, Object> secondary = secondaryAttributeKey != null ? getAttributeMap(attributes, secondaryAttributeKey) : primary;
+        return secondary.get(nicknameKey) != null ? secondary.get(nicknameKey).toString() : UUID.randomUUID().toString().substring(0, 21);
+    }
+
+    public String getEmail(Map<String, Object> attributes) {
+        Map<String, Object> primary = getAttributeMap(attributes, mainAttributeKey);
+        return primary.get(emailKey).toString();
+    }
+
+    private Map<String, Object> getAttributeMap(Map<String, Object> attributes, String key) {
+        return key != null && attributes.containsKey(key) ? (Map<String, Object>) attributes.get(key) : attributes;
+    }
+
+    public static OAuthInfo from(String provider) {
+        return Arrays.stream(OAuthInfo.values())
+                .filter(item -> item.name().equalsIgnoreCase(provider))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid provider: " + provider));
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -28,6 +28,7 @@ CREATE TABLE `users` (
     `account_lock` BOOLEAN NOT NULL,
     `last_password_expired` TIMESTAMP NOT NULL,
     `profile_image` VARCHAR(255),
+    `is_default_nickname` BOOLEAN NOT NULL,
     `is_marketing` BOOLEAN NOT NULL,
     `is_alarm` BOOLEAN NOT NULL,
     `role` VARCHAR(10) NOT NULL,

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -28,7 +28,7 @@ CREATE TABLE `users` (
     `account_lock` BOOLEAN NOT NULL,
     `last_password_expired` TIMESTAMP NOT NULL,
     `profile_image` VARCHAR(255),
-    `is_default_nickname` BOOLEAN NOT NULL,
+    `is_default_nickname` BOOLEAN NOT NULL DEFAULT 0,
     `is_marketing` BOOLEAN NOT NULL,
     `is_alarm` BOOLEAN NOT NULL,
     `role` VARCHAR(10) NOT NULL,

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -19,12 +19,11 @@ DROP TABLE IF EXISTS `users`;
 CREATE TABLE `users` (
     `user_id` VARCHAR(36) NOT NULL,
     `password` VARCHAR(255) NOT NULL,
-    `username` VARCHAR(15) NOT NULL,
-    `phone_number` VARCHAR(11) NOT NULL UNIQUE,
-    `birth_date` VARCHAR(6) NOT NULL,
+    `phone_number` VARCHAR(11) UNIQUE,
+    `birth_date` VARCHAR(6),
     `email` VARCHAR(255) NOT NULL UNIQUE,
     `nickname` VARCHAR(255) NOT NULL UNIQUE,
-    `gender` VARCHAR(10) NOT NULL,
+    `gender` VARCHAR(10),
     `social_root` VARCHAR(20),
     `password_count` INT NOT NULL DEFAULT 0,
     `account_lock` BOOLEAN NOT NULL,
@@ -62,8 +61,6 @@ CREATE TABLE `notification` (
     `is_read` BOOLEAN NOT NULL DEFAULT FALSE,
     `created_at` TIMESTAMP NOT NULL,
     `modified_at` TIMESTAMP NOT NULL,
-    `deleted_at` TIMESTAMP NULL,
-    `is_deleted` BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (`notification_id`),
     FOREIGN KEY (`user_id`) REFERENCES `users`(`user_id`)
 );

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -8,7 +8,6 @@ DROP TABLE IF EXISTS `like_place`;
 DROP TABLE IF EXISTS `like_list`;
 DROP TABLE IF EXISTS `users_post`;
 DROP TABLE IF EXISTS `post_comment`;
-DROP TABLE IF EXISTS `comment`;
 DROP TABLE IF EXISTS `post`;
 DROP TABLE IF EXISTS `board`;
 DROP TABLE IF EXISTS `notification`;


### PR DESCRIPTION
### ✨ 작업 내용

- [x] username 제거 및 null 여부 수정
- [x] 닉네임 글자 수 2 ~ 20자로 수정
- [x] isDefaultNickname entity에 추가
- [x] OAuth 회원가입 로직 수정
- [x] OAuth 회원가입 시 닉네임 선택안할 경우 nickname 임의 부여 후 redirect 설정
- [x] 소셜 회원가입 제약조건 추가 (nickname length 및 nickname 제약 수정)

### ✨ 코멘트

1. 일단 저장하고, 필수 정보가 입력 여부 확인 후 로그인 하면 입력 창으로 계속 리다이렉트 시키기
    => Nickname 임의로 부여
2. 추가 정보는 회원 정보 수정에서 받기(생년월일, 성별, 핸드폰번호)

- nickname만 받는 API 추가(필수 정보)
- 필수 정보 기재한 사람인지 확인하는 컬럼 추가해서 redirect로 추가 정보 받기
    => 만약에 이 사람이 필수 값이 누락된 사람인지 별도 컬럼 추가
        닉네임을 UUID.RandomUUID => nickname => Not null
        설정은 안 한 사용자면 false/true 준 다음에 그걸로 판별
- 추가 정보 받는 API 추가 => 내 정보 수정 기능과 같은 것
- OAuth Validation 추가
    => OAuth 닉네임이 자체 회원가입 닉네임이랑 중복이면 UNIQUE 제약 어떻게 해결할지 결정 해야 함
    => 만약 OAuth에서 nickname이 20글자 이상이면 이것도 리다이렉트 하게 하기 => 이건 일단 공유하고 의사 결정 필요
- 닉네임 글자수 20글자로 늘리기

### Git Close

- close #31 