### PR TITLE
Feat/28

### DIFF
--- a/src/main/java/com/picnee/travel/domain/notification/dto/event/CommentLikeEvent.java
+++ b/src/main/java/com/picnee/travel/domain/notification/dto/event/CommentLikeEvent.java
@@ -10,11 +10,11 @@ import java.util.UUID;
 @Builder
 @AllArgsConstructor
 public class CommentLikeEvent implements NotificationEvent {
-    private final UUID postId;
+    private final UUID commentId;
 
     @Override
     public UUID getTargetId() {
-        return postId;
+        return commentId;
     }
 
     @Override
@@ -26,7 +26,7 @@ public class CommentLikeEvent implements NotificationEvent {
     public Notification toEntity(User user) {
         return Notification.builder()
                 .notificationType(NotificationType.COMMENT_LIKE)
-                .targetId(postId)
+                .targetId(commentId)
                 .isRead(false)
                 .user(user)
                 .build();

--- a/src/main/java/com/picnee/travel/domain/notification/dto/event/CommentLikeEvent.java
+++ b/src/main/java/com/picnee/travel/domain/notification/dto/event/CommentLikeEvent.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 @Builder
 @AllArgsConstructor
-public class PostLikeEvent implements NotificationEvent {
+public class CommentLikeEvent implements NotificationEvent {
     private final UUID postId;
 
     @Override
@@ -19,13 +19,13 @@ public class PostLikeEvent implements NotificationEvent {
 
     @Override
     public NotificationType getNotificationType() {
-        return NotificationType.POST_LIKE;
+        return NotificationType.COMMENT_LIKE;
     }
 
     @Override
     public Notification toEntity(User user) {
         return Notification.builder()
-                .notificationType(NotificationType.POST_LIKE)
+                .notificationType(NotificationType.COMMENT_LIKE)
                 .targetId(postId)
                 .isRead(false)
                 .user(user)

--- a/src/main/java/com/picnee/travel/domain/notification/entity/Notification.java
+++ b/src/main/java/com/picnee/travel/domain/notification/entity/Notification.java
@@ -37,7 +37,6 @@ public class Notification extends BaseEntity {
     @Column(name = "notification_type")
     @Enumerated(EnumType.STRING)
     private NotificationType notificationType;
-    @UuidGenerator(style = RANDOM)
     @JdbcTypeCode(SqlTypes.VARCHAR)
     @Column(name = "target_id", columnDefinition = "VARCHAR(36)")
     private UUID targetId;

--- a/src/main/java/com/picnee/travel/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/picnee/travel/domain/notification/entity/NotificationType.java
@@ -2,6 +2,6 @@ package com.picnee.travel.domain.notification.entity;
 
 public enum NotificationType {
     POST_COMMENT,    // 작성한 게시글에 댓글
-    POST_LIKE,       // 작성한 게시글에 좋아요
+    COMMENT_LIKE,    // 작성한 댓글에 좋아요
     REVIEW_SCORE     // 작성한 리뷰에 별점
 }

--- a/src/main/java/com/picnee/travel/domain/notification/eventListener/NotificationEventListener.java
+++ b/src/main/java/com/picnee/travel/domain/notification/eventListener/NotificationEventListener.java
@@ -1,12 +1,11 @@
 package com.picnee.travel.domain.notification.eventListener;
 
 import com.picnee.travel.domain.notification.dto.event.PostCommentEvent;
-import com.picnee.travel.domain.notification.dto.event.PostLikeEvent;
+import com.picnee.travel.domain.notification.dto.event.CommentLikeEvent;
 import com.picnee.travel.domain.notification.dto.event.ReviewScoreEvent;
 import com.picnee.travel.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -23,7 +22,7 @@ public class NotificationEventListener {
     }
 
     @TransactionalEventListener
-    public void handlePostLikeEvent(PostLikeEvent event) {
+    public void handlePostLikeEvent(CommentLikeEvent event) {
         notificationService.create(event);
     }
 

--- a/src/main/java/com/picnee/travel/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/picnee/travel/domain/notification/service/NotificationService.java
@@ -12,7 +12,6 @@ import com.picnee.travel.domain.postComment.service.PostCommentService;
 import com.picnee.travel.domain.review.service.ReviewService;
 import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
 import com.picnee.travel.domain.user.entity.User;
-import com.picnee.travel.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,14 +35,17 @@ public class NotificationService {
     private final PostService postService;
     private final PostCommentService postCommentService;
 
+    // TODO 본인이 발행한 알림(본인이 작성한 게시글에 본인이 댓글 작성 등)은 뜨지 않게 하기
+    // TODO 중복 알림은 안 뜨게 하기(좋아요 토글 같은 경우는 적용 필요)
+
     /**
      * 알림 생성
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void create(NotificationEvent event) {
+    public Notification create(NotificationEvent event) {
         User user = findUserByTargetIdAndType(event.getTargetId(), event.getNotificationType());
 
-        notificationRepository.save(event.toEntity(user));
+        return notificationRepository.save(event.toEntity(user));
     }
 
     /**

--- a/src/main/java/com/picnee/travel/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/picnee/travel/domain/notification/service/NotificationService.java
@@ -8,9 +8,11 @@ import com.picnee.travel.domain.notification.exception.NotFoundNotificationExcep
 import com.picnee.travel.domain.notification.exception.NotNotificationRecipientException;
 import com.picnee.travel.domain.notification.repository.NotificationRepository;
 import com.picnee.travel.domain.post.service.PostService;
+import com.picnee.travel.domain.postComment.service.PostCommentService;
 import com.picnee.travel.domain.review.service.ReviewService;
 import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
 import com.picnee.travel.domain.user.entity.User;
+import com.picnee.travel.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,6 +34,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final ReviewService reviewService;
     private final PostService postService;
+    private final PostCommentService postCommentService;
 
     /**
      * 알림 생성
@@ -73,7 +76,9 @@ public class NotificationService {
 
     public User findUserByTargetIdAndType(UUID targetId, NotificationType notificationType) {
         return switch (notificationType) {
-            case POST_COMMENT, POST_LIKE -> postService.findById(targetId)
+            case POST_COMMENT -> postService.findById(targetId)
+                    .getUser();
+            case COMMENT_LIKE -> postCommentService.findById(targetId)
                     .getUser();
             case REVIEW_SCORE -> reviewService.findById(targetId)
                     .getUser();

--- a/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
@@ -1,5 +1,6 @@
 package com.picnee.travel.domain.postComment.service;
 
+import com.picnee.travel.domain.notification.dto.event.PostCommentEvent;
 import com.picnee.travel.domain.post.entity.Post;
 import com.picnee.travel.domain.post.service.PostService;
 import com.picnee.travel.domain.postComment.dto.req.CreatePostCommentReq;
@@ -15,6 +16,7 @@ import com.picnee.travel.domain.user.service.UserService;
 import com.picnee.travel.domain.userPostCommet.service.UserPostCommentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +35,7 @@ public class PostCommentService {
     private final PostService postService;
     private final UserPostCommentService userPostCommentService;
     private final PostCommentRepository postCommentRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 댓글 생성
@@ -41,6 +44,8 @@ public class PostCommentService {
     public PostComment create(UUID postId, CreatePostCommentReq dto, AuthenticatedUserReq auth) {
         User user = userService.findByEmail(auth.getEmail());
         Post post = postService.findByIdNotDeletedPost(postId);
+
+        eventPublisher.publishEvent(new PostCommentEvent(postId));
 
         return postCommentRepository.save(CreatePostCommentReq.toEntity(dto, user, post));
     }

--- a/src/main/java/com/picnee/travel/domain/userPostCommet/service/UserPostCommentService.java
+++ b/src/main/java/com/picnee/travel/domain/userPostCommet/service/UserPostCommentService.java
@@ -1,11 +1,13 @@
 package com.picnee.travel.domain.userPostCommet.service;
 
+import com.picnee.travel.domain.notification.dto.event.CommentLikeEvent;
 import com.picnee.travel.domain.postComment.entity.PostComment;
 import com.picnee.travel.domain.user.entity.User;
 import com.picnee.travel.domain.userPostCommet.entity.UserPostComment;
 import com.picnee.travel.domain.userPostCommet.repository.UserPostCommentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserPostCommentService {
 
     private final UserPostCommentRepository userPostCommentRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public boolean incrementLike(PostComment postComment, User user) {
         UserPostComment userPostComment = userPostCommentRepository.findByUserAndPostComment(user, postComment)
@@ -26,6 +29,8 @@ public class UserPostCommentService {
         // 좋아요 x -> 좋아요
         if (!likeState) {
             userPostComment.like();
+            eventPublisher.publishEvent(new CommentLikeEvent(userPostComment.getPostComment().getId()));
+            log.info("@@@@@userPostCommentId = {}", userPostComment.getPostComment().getId());
             return likeState;
         }
 
@@ -39,7 +44,7 @@ public class UserPostCommentService {
         UserPostComment userPostComment = UserPostComment.builder()
                 .user(user)
                 .postComment(postComment)
-                .isLiked(true) // 최초 생성 시 좋아요 상태는 true
+                .isLiked(false) // 최초 생성 시 좋아요 상태는 true
                 .build();
 
         return userPostCommentRepository.save(userPostComment);

--- a/src/main/java/com/picnee/travel/domain/userPostCommet/service/UserPostCommentService.java
+++ b/src/main/java/com/picnee/travel/domain/userPostCommet/service/UserPostCommentService.java
@@ -44,7 +44,7 @@ public class UserPostCommentService {
         UserPostComment userPostComment = UserPostComment.builder()
                 .user(user)
                 .postComment(postComment)
-                .isLiked(false) // 최초 생성 시 좋아요 상태는 true
+                .isLiked(false)
                 .build();
 
         return userPostCommentRepository.save(userPostComment);

--- a/src/main/java/com/picnee/travel/domain/userPostCommet/service/UserPostCommentService.java
+++ b/src/main/java/com/picnee/travel/domain/userPostCommet/service/UserPostCommentService.java
@@ -30,7 +30,6 @@ public class UserPostCommentService {
         if (!likeState) {
             userPostComment.like();
             eventPublisher.publishEvent(new CommentLikeEvent(userPostComment.getPostComment().getId()));
-            log.info("@@@@@userPostCommentId = {}", userPostComment.getPostComment().getId());
             return likeState;
         }
 

--- a/src/test/java/com/picnee/travel/domain/notification/service/NotificationServiceForTest.java
+++ b/src/test/java/com/picnee/travel/domain/notification/service/NotificationServiceForTest.java
@@ -1,0 +1,35 @@
+package com.picnee.travel.domain.notification.service;
+
+import com.picnee.travel.domain.notification.dto.event.NotificationEvent;
+import com.picnee.travel.domain.notification.entity.Notification;
+import com.picnee.travel.domain.notification.repository.NotificationRepository;
+import com.picnee.travel.domain.post.service.PostService;
+import com.picnee.travel.domain.postComment.service.PostCommentService;
+import com.picnee.travel.domain.review.service.ReviewService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@Profile("test")
+@Primary
+public class NotificationServiceForTest extends NotificationService {
+
+    public NotificationServiceForTest(NotificationRepository notificationRepository,
+                                   ReviewService reviewService,
+                                   PostService postService,
+                                   PostCommentService postCommentService) {
+        super(notificationRepository, reviewService, postService, postCommentService);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public Notification create(NotificationEvent event) {
+        return super.create(event);
+    }
+}

--- a/src/test/java/com/picnee/travel/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/picnee/travel/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,65 @@
+package com.picnee.travel.domain.notification.service;
+
+import com.picnee.travel.domain.notification.dto.event.PostCommentEvent;
+import com.picnee.travel.domain.notification.dto.res.FindNotificationRes;
+import com.picnee.travel.domain.notification.entity.Notification;
+import com.picnee.travel.domain.notification.entity.NotificationType;
+import com.picnee.travel.domain.post.entity.CreateTestPost;
+import com.picnee.travel.domain.post.entity.Post;
+import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
+import com.picnee.travel.domain.user.entity.CreateTestUser;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+public class NotificationServiceTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Autowired
+    CreateTestUser createTestUser;
+
+    @Autowired
+    CreateTestPost createTestPost;
+
+    private AuthenticatedUserReq user;
+    private Post post;
+    private Notification notification;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        user = createTestUser.createUser();
+        post = createTestPost.createPost(user);
+        notification = notificationService.create(new PostCommentEvent(post.getId()));
+    }
+
+    @Test
+    @DisplayName("알림 생성 : 게시글에 댓글 알림 생성")
+    void test1() {
+        assertThat(notification.getUser().getId()).isEqualTo(user.getId());
+        assertThat(notification.getTargetId()).isEqualTo(post.getId());
+        assertThat(notification.getNotificationType()).isEqualTo(NotificationType.POST_COMMENT);
+    }
+
+    @Test
+    @DisplayName("안 읽은 알림 확인 : 게시글에 댓글 작성 후 안 읽은 알림 확인")
+    void test2() {
+        List<FindNotificationRes> notificationList = notificationService.getUnreadNotifications(user);
+
+        assertThat(notificationList.size()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/picnee/travel/domain/post/entity/CreateTestPost.java
+++ b/src/test/java/com/picnee/travel/domain/post/entity/CreateTestPost.java
@@ -1,0 +1,41 @@
+package com.picnee.travel.domain.post.entity;
+
+import com.picnee.travel.domain.board.entity.BoardCategory;
+import com.picnee.travel.domain.board.entity.Region;
+import com.picnee.travel.domain.post.dto.req.CreatePostReq;
+import com.picnee.travel.domain.post.service.PostService;
+import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
+import com.picnee.travel.domain.user.entity.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+@Component
+public class CreateTestPost {
+
+    @Autowired
+    private PostService postService;
+
+    private CreatePostReq createPostReq;
+
+    /**
+     * 테스트 게시글 생성
+     * */
+    public Post createPost(AuthenticatedUserReq auth) {
+        CreatePostReq postReq = CreatePostReq.builder()
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .region(Region.KANSAI)
+                .boardCategory(BoardCategory.RESTAURANT)
+                .build();
+
+        return postService.create(postReq, auth);
+    }
+}


### PR DESCRIPTION
### ✨ 작업 내용

- [x] targetId에 붙였던 Random UUID 생성 어노테이션 제거
- [x] COMMENT_LIKE 유형 추가 및 POST_LIKE 유형 제거
- [x] COMMNET_LIKE와 POST_COMMENT 알림 발행
- [x] 테스트 코드 추가

### ✨ 코멘트

- notificationService.create()의 `@Transactional(propagation = Propagation.REQUIRES_NEW)` 때문에 테스트에서 post 생성이 계속 롤백되어 테스트용 서비스를 추가했습니다.

### Git Close

- close #28 
