### PR TITLE
test/43

### DIFF
--- a/src/main/java/com/picnee/travel/api/UserController.java
+++ b/src/main/java/com/picnee/travel/api/UserController.java
@@ -7,14 +7,11 @@ import com.picnee.travel.domain.user.dto.req.CreateUserReq;
 import com.picnee.travel.domain.user.dto.req.LoginUserReq;
 import com.picnee.travel.domain.user.dto.req.UpdateUserNicknameReq;
 import com.picnee.travel.domain.user.dto.res.CheckDuplicateRes;
-import com.picnee.travel.domain.user.dto.res.UserRes;
 import com.picnee.travel.domain.user.entity.User;
 import com.picnee.travel.domain.user.service.UserService;
-import com.picnee.travel.global.jwt.dto.res.AccessTokenRes;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
 import com.picnee.travel.global.redis.service.RedisService;
 import com.picnee.travel.global.security.annotation.AuthenticatedUser;
-import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -77,7 +74,7 @@ public class UserController implements UserApi {
 
     @PatchMapping
     public ResponseEntity<String> updateUser(@AuthenticatedUser AuthenticatedUserReq auth,
-                                             @Valid @RequestBody UpdateUser dto) {
+                                             @Valid @RequestBody UpdateUserReq dto) {
         User user = userService.updateUser(auth, dto);
         return ResponseEntity.status(OK).body(user.getId().toString());
     }

--- a/src/main/java/com/picnee/travel/api/in/UserApi.java
+++ b/src/main/java/com/picnee/travel/api/in/UserApi.java
@@ -6,8 +6,6 @@ import com.picnee.travel.domain.user.dto.req.CreateUserReq;
 import com.picnee.travel.domain.user.dto.req.LoginUserReq;
 import com.picnee.travel.domain.user.dto.req.UpdateUserNicknameReq;
 import com.picnee.travel.domain.user.dto.res.CheckDuplicateRes;
-import com.picnee.travel.domain.user.dto.res.UserRes;
-import com.picnee.travel.global.jwt.dto.res.AccessTokenRes;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,7 +24,7 @@ public interface UserApi {
     public ResponseEntity<String> updateNickname(AuthenticatedUserReq auth, UpdateUserNicknameReq dto);
 
     @Operation(summary = "내 정보 수정", description = "마이페이지에서 내 정보를 수정한다.")
-    public ResponseEntity<String> updateUser(AuthenticatedUserReq auth, UpdateUser dto);
+    public ResponseEntity<String> updateUser(AuthenticatedUserReq auth, UpdateUserReq dto);
   
     @Operation(summary = "이메일 중복 확인", description = "이메일이 중복인지 확인한다.")
     public ResponseEntity<CheckDuplicateRes> checkEmailDuplicate(String email);

--- a/src/main/java/com/picnee/travel/domain/user/dto/req/UpdateUserReq.java
+++ b/src/main/java/com/picnee/travel/domain/user/dto/req/UpdateUserReq.java
@@ -1,7 +1,6 @@
 package com.picnee.travel.domain.user.dto.req;
 
 import com.picnee.travel.domain.user.entity.Gender;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
@@ -9,7 +8,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class UpdateUser {
+public class UpdateUserReq {
 
     @Pattern(regexp = "^(?=.*[A-Za-z가-힣])[A-Za-z\\d가-힣]{2,20}$", message = "닉네임은 2자 이상 20자 이하이며, 영어와 한글이 반드시 하나 이상은 포함되어야 합니다.")
     private String nickname;

--- a/src/main/java/com/picnee/travel/domain/user/entity/User.java
+++ b/src/main/java/com/picnee/travel/domain/user/entity/User.java
@@ -41,9 +41,9 @@ public class User extends SoftDeleteBaseEntity {
     private String phoneNumber;
     @Column(name = "birth_date")
     private String birthDate;
-    @Column(name = "email")
+    @Column(unique = true, name = "email")
     private String email;
-    @Column(name = "nickname")
+    @Column(unique = true, name = "nickname")
     private String nickname;
     @Column(name = "gender")
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/picnee/travel/domain/user/entity/User.java
+++ b/src/main/java/com/picnee/travel/domain/user/entity/User.java
@@ -2,7 +2,7 @@ package com.picnee.travel.domain.user.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.picnee.travel.domain.base.entity.SoftDeleteBaseEntity;
-import com.picnee.travel.domain.user.dto.req.UpdateUser;
+import com.picnee.travel.domain.user.dto.req.UpdateUserReq;
 import com.picnee.travel.domain.usersPost.entity.UsersPost;
 import jakarta.persistence.*;
 import lombok.*;
@@ -99,7 +99,7 @@ public class User extends SoftDeleteBaseEntity {
     /**
      * 내 정보 수정
      */
-    public void update(UpdateUser dto, PasswordEncoder passwordEncoder) {
+    public void update(UpdateUserReq dto, PasswordEncoder passwordEncoder) {
         this.nickname = dto.getNickname() == null ? this.nickname : dto.getNickname();
         this.password = dto.getNewPassword() == null ? this.password : passwordEncoder.encode(dto.getNewPassword());
         this.phoneNumber = dto.getPhoneNumber() == null ? this.phoneNumber : dto.getPhoneNumber().replaceAll("-", "");

--- a/src/main/java/com/picnee/travel/domain/user/service/UserService.java
+++ b/src/main/java/com/picnee/travel/domain/user/service/UserService.java
@@ -47,7 +47,7 @@ public class UserService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     @Transactional
-    public void create(CreateUserReq dto) {
+    public User create(CreateUserReq dto) {
         User user = User.builder()
                 .email(dto.getEmail())
                 .nickname(dto.getNickname())
@@ -63,7 +63,7 @@ public class UserService {
                 .state(State.ACTIVE)
                 .build();
 
-        userRepository.save(user);
+        return userRepository.save(user);
     }
 
     /**

--- a/src/main/java/com/picnee/travel/domain/user/service/UserService.java
+++ b/src/main/java/com/picnee/travel/domain/user/service/UserService.java
@@ -3,23 +3,18 @@ package com.picnee.travel.domain.user.service;
 import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
 import com.picnee.travel.domain.user.dto.req.CreateUserReq;
 import com.picnee.travel.domain.user.dto.req.LoginUserReq;
-import com.picnee.travel.domain.user.dto.req.UpdateUser;
+import com.picnee.travel.domain.user.dto.req.UpdateUserReq;
 import com.picnee.travel.domain.user.dto.res.CheckDuplicateRes;
-import com.picnee.travel.domain.user.dto.res.UserRes;
 import com.picnee.travel.domain.user.entity.Role;
 import com.picnee.travel.domain.user.entity.State;
 import com.picnee.travel.domain.user.entity.User;
 import com.picnee.travel.domain.user.exception.*;
 import com.picnee.travel.domain.user.repository.UserRepository;
-import com.picnee.travel.global.jwt.dto.res.AccessTokenRes;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
 import com.picnee.travel.global.jwt.provider.TokenProvider;
 import com.picnee.travel.global.redis.service.RedisService;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.antlr.v4.runtime.Token;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -28,7 +23,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 
 import static com.picnee.travel.domain.user.entity.State.*;
@@ -121,7 +115,7 @@ public class UserService {
      * 내 정보 수정
      */
     @Transactional
-    public User updateUser(AuthenticatedUserReq auth, UpdateUser dto) {
+    public User updateUser(AuthenticatedUserReq auth, UpdateUserReq dto) {
         User user = findByEmail(auth.getEmail());
 
         if (!passwordEncoder.matches(dto.getOldPassword(), user.getPassword())) {

--- a/src/test/java/com/picnee/travel/TravelApplicationTests.java
+++ b/src/test/java/com/picnee/travel/TravelApplicationTests.java
@@ -2,8 +2,10 @@ package com.picnee.travel;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class TravelApplicationTests {
 
 	@Test

--- a/src/test/java/com/picnee/travel/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/picnee/travel/domain/user/controller/UserControllerTest.java
@@ -131,7 +131,6 @@ class UserControllerTest {
 
     }
 
-    //TODO : 여기부터
     @Test
     @DisplayName("내정보 변경 성공 response 테스트")
     void testUpdateUserSuccess() throws Exception {

--- a/src/test/java/com/picnee/travel/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/picnee/travel/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,193 @@
+package com.picnee.travel.domain.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picnee.travel.api.UserController;
+import com.picnee.travel.domain.user.dto.req.*;
+import com.picnee.travel.domain.user.dto.res.CheckDuplicateRes;
+import com.picnee.travel.domain.user.dto.res.UserRes;
+import com.picnee.travel.domain.user.entity.Gender;
+import com.picnee.travel.domain.user.entity.State;
+import com.picnee.travel.domain.user.entity.User;
+import com.picnee.travel.domain.user.service.UserService;
+import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
+import com.picnee.travel.global.redis.service.RedisService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Slf4j
+@WebMvcTest(UserController.class) // UserController 단위테스트
+@MockBean(JpaMetamodelMappingContext.class) // jpa동작하지않도록
+@AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터 제외
+@ActiveProfiles("test")
+class UserControllerTest {
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private RedisService redisService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final User mockUser = User.builder()
+                .id(UUID.randomUUID())
+                .email("mockUser@naver.com")
+                .nickname("mockUser")
+                .password("abcd1234!")
+                .isMarketing(true)
+                .isAlarm(true)
+                .state(State.ACTIVE)
+                .build();
+
+    @Test
+    @DisplayName("회원가입 성공 response 테스트")
+    void testCreateUserSuccess() throws Exception {
+        CreateUserReq createUserReq = CreateUserReq.builder()
+                .email("createUser@naver.com")
+                .nickname("createUser")
+                .password("abcd1234!")
+                .isMarketing(true)
+                .isAlarm(true)
+                .build();
+        
+        given(userService.create(any(CreateUserReq.class))).willReturn(mockUser);
+        
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createUserReq)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("로그인 성공 response 테스트")
+    void testLoginUserSuccess() throws Exception {
+
+        LoginUserReq loginUserReq = LoginUserReq.builder().build();
+
+        UserRes userRes = UserRes.builder()
+                .userId(UUID.randomUUID())
+                .nickName("TestUser")
+                .build();
+
+        JwtTokenRes jwtTokenRes = JwtTokenRes.builder()
+                .grantType("Bearer ")
+                .accessToken("accessTokenValue")
+                .refreshToken("refreshTokenValue")
+                .userRes(userRes)
+                .build();
+
+        given(userService.login(any(LoginUserReq.class))).willReturn(jwtTokenRes);
+
+        mockMvc.perform(post("/users/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginUserReq)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().value("ACCESS_TOKEN", "accessTokenValue"))
+                .andExpect(cookie().value("REFRESH_TOKEN", "refreshTokenValue"));
+
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 성공 response 테스트")
+    void testUpdateNicknameSuccess() throws Exception {
+        String updateNickname = "updateNickname";
+
+        UpdateUserNicknameReq updateUserNicknameReq = UpdateUserNicknameReq.builder()
+                .nickname(updateNickname)
+                .build();
+
+        User user = User.builder().nickname("mockNickname").build();
+
+        given(userService.updateNickname(any(), any()))
+                .willReturn(user);
+
+        mockMvc.perform(patch("/users/nickname")
+                        .header("AccessToken", "validAccessToken")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateUserNicknameReq)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("mockNickname"));
+
+    }
+
+    //TODO : 여기부터
+    @Test
+    @DisplayName("내정보 변경 성공 response 테스트")
+    void testUpdateUserSuccess() throws Exception {
+
+        UpdateUserReq updateUserReq = UpdateUserReq.builder()
+                .nickname("testUser")
+                .oldPassword("test!!AA11")
+                .newPassword("testChange!!AA11")
+                .isMarketing(true)
+                .isAlarm(true)
+                .phoneNumber("010-0000-0000")
+                .gender(Gender.MALE)
+                .birthDate("")
+                .build();
+
+        given(userService.updateUser(any(), any()))
+                .willReturn(mockUser);
+
+        mockMvc.perform(patch("/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateUserReq)))
+                .andExpect(status().isOk())
+                .andExpect(content().string(mockUser.getId().toString()));
+
+    }
+
+    @Test
+    @DisplayName("이메일 중복체크 성공 response 테스트")
+    void testEmailDuplicateSuccess() throws Exception {
+
+        CheckDuplicateRes dupRes = CheckDuplicateRes.builder().isExists(true).build();
+
+        given(userService.checkEmailDuplicate(eq("checkDupEmail1234@naver.com")))
+                .willReturn(dupRes);
+
+        mockMvc.perform(get("/users/email/exists")
+                        .param("email", "checkDupEmail1234@naver.com")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.exists").value(true));
+    }
+
+    @Test
+    @DisplayName("닉네임 중복체크 성공 response 테스트")
+    void testNicknameDuplicateSuccess() throws Exception {
+
+        CheckDuplicateRes dupRes = CheckDuplicateRes.builder().isExists(true).build();
+
+        given(userService.checkNicknameDuplicate(eq("dupNickname")))
+                .willReturn(dupRes);
+
+        mockMvc.perform(get("/users/nickname/exists")
+                        .param("nickname", "dupNickname")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.exists").value(true));
+    }
+
+}

--- a/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
@@ -1,0 +1,69 @@
+package com.picnee.travel.domain.user.service;
+
+import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
+import com.picnee.travel.domain.user.dto.req.CreateUserReq;
+import com.picnee.travel.domain.user.entity.CreateTestUser;
+import com.picnee.travel.domain.user.entity.User;
+import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+public class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    CreateTestUser createTestUser;
+
+    private AuthenticatedUserReq user;
+    private AuthenticatedUserReq anotherUser;
+    private JwtTokenRes jwtTokenRes;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        user = createTestUser.createUser();
+        anotherUser = createTestUser.createAnotherUser();
+        jwtTokenRes = createTestUser.createJwtToken();
+    }
+
+    @Test
+    @DisplayName("유저 생성 성공")
+    void test1() {
+        CreateUserReq createUserReq = CreateUserReq.builder()
+                .email("test@gmail.com")
+                .nickname("testName")
+                .password("abcd1234!")
+                .isMarketing(true)
+                .isAlarm(true)
+                .build();
+
+        User testUser = userService.create(createUserReq);
+
+        assertThat(testUser).isNotNull();
+        assertThat(testUser.getEmail()).isEqualTo("test@gmail.com");
+        assertThat(testUser.getNickname()).isEqualTo("testName");
+        assertThat(passwordEncoder.matches("abcd1234!", testUser.getPassword())).isTrue();
+        assertThat(testUser.getIsMarketing()).isTrue();
+        assertThat(testUser.getIsAlarm()).isTrue();
+    }
+
+
+
+
+}

--- a/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
@@ -5,6 +5,8 @@ import com.picnee.travel.domain.user.dto.req.CreateUserReq;
 import com.picnee.travel.domain.user.dto.req.LoginUserReq;
 import com.picnee.travel.domain.user.entity.CreateTestUser;
 import com.picnee.travel.domain.user.entity.User;
+import com.picnee.travel.domain.user.exception.LoginFailedException;
+import com.picnee.travel.domain.user.exception.NotFoundEmailException;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
 import com.picnee.travel.global.jwt.provider.TokenProvider;
 import lombok.extern.slf4j.Slf4j;
@@ -84,7 +86,34 @@ public class UserServiceTest {
         assertThat(jwtTokenRes.getUserRes().getNickName()).isEqualTo("tester");
     }
 
+    @Test
+    @DisplayName("비밀번호 미일치 로그인 실패")
+    void test3() {
+        String email = "testUser@naver.com";
+        String failPassword = "failPassword";
+        LoginUserReq failLoginUserReq = LoginUserReq.builder()
+                .email(email)
+                .password(failPassword)
+                .build();
 
+        assertThatThrownBy(() -> userService.login(failLoginUserReq))
+                .isInstanceOf(LoginFailedException.class)
+                .hasMessageContaining("비밀번호");
+    }
 
+    @Test
+    @DisplayName("갖고있지 않은 이메일 정보")
+    void test4() {
+        String failEmail = "unknown@naver.com";
+        String password = "abcd1234!";
+        LoginUserReq loginUserReq = LoginUserReq.builder()
+                .email(failEmail)
+                .password(password)
+                .build();
+
+        assertThatThrownBy(() -> userService.login(loginUserReq))
+                .isInstanceOf(NotFoundEmailException.class)
+                .hasMessage("존재하지 않는 계정입니다.");
+    }
 
 }

--- a/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
@@ -92,7 +92,7 @@ public class UserServiceTest {
     @Description("유니크 제약조건 확인")
     void test1_1() {
 
-        String duplicatedEmail = "test@gmail.com";
+        String duplicatedEmail = "testUser@naver.com";
 
         CreateUserReq createDuplicateUserReq = CreateUserReq.builder()
                 .email(duplicatedEmail) // 중복된 이메일

--- a/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import com.picnee.travel.domain.user.entity.CreateTestUser;
 import com.picnee.travel.domain.user.entity.User;
 import com.picnee.travel.domain.user.exception.LoginFailedException;
 import com.picnee.travel.domain.user.exception.NotFoundEmailException;
+import com.picnee.travel.domain.user.repository.UserRepository;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
 import com.picnee.travel.global.jwt.provider.TokenProvider;
 import lombok.extern.slf4j.Slf4j;
@@ -40,9 +41,12 @@ public class UserServiceTest {
     private PasswordEncoder passwordEncoder;
     @Autowired
     private TokenProvider tokenProvider;
+    @Autowired
+    private UserRepository userRepository;
 
     @BeforeEach
     void setUp() throws Exception {
+        userRepository.deleteAll();
         user = createTestUser.createUser();
         anotherUser = createTestUser.createAnotherUser();
         jwtTokenRes = createTestUser.createJwtToken();
@@ -67,6 +71,25 @@ public class UserServiceTest {
         assertThat(passwordEncoder.matches("abcd1234!", testUser.getPassword())).isTrue();
         assertThat(testUser.getIsMarketing()).isTrue();
         assertThat(testUser.getIsAlarm()).isTrue();
+    }
+
+    // Todo : 동일한유저 확인테스트 해야함
+    @Test
+    @DisplayName("유저 생성 실패 - 이미 존재하는 닉네임")
+    void test1_1() {
+        CreateUserReq createUserReq = CreateUserReq.builder()
+                .email("testUser@naver.com")
+                .nickname("tester")
+                .password("abcd1234!")
+                .isMarketing(true)
+                .isAlarm(true)
+                .build();
+
+//        Boolean findUser = userRepository.existsByNickname("tester");
+//
+//        System.out.println("test111" + findUser);
+
+        assertThatThrownBy(()-> userService.create(createUserReq)).isInstanceOf(Exception.class);
     }
 
     @Test
@@ -114,6 +137,16 @@ public class UserServiceTest {
         assertThatThrownBy(() -> userService.login(loginUserReq))
                 .isInstanceOf(NotFoundEmailException.class)
                 .hasMessage("존재하지 않는 계정입니다.");
+    }
+
+    @Test
+    @DisplayName("닉네임 업데이트 테스트")
+    void test5() {
+        String updateNickname = "updateNickName";
+
+        User updatedUser = userService.updateNickname(user, updateNickname);
+
+        assertThat(updatedUser.getNickname()).isEqualTo(updateNickname);
     }
 
 }

--- a/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/picnee/travel/domain/user/service/UserServiceTest.java
@@ -2,9 +2,11 @@ package com.picnee.travel.domain.user.service;
 
 import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
 import com.picnee.travel.domain.user.dto.req.CreateUserReq;
+import com.picnee.travel.domain.user.dto.req.LoginUserReq;
 import com.picnee.travel.domain.user.entity.CreateTestUser;
 import com.picnee.travel.domain.user.entity.User;
 import com.picnee.travel.global.jwt.dto.res.JwtTokenRes;
+import com.picnee.travel.global.jwt.provider.TokenProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +36,8 @@ public class UserServiceTest {
     private JwtTokenRes jwtTokenRes;
     @Autowired
     private PasswordEncoder passwordEncoder;
+    @Autowired
+    private TokenProvider tokenProvider;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -61,6 +65,23 @@ public class UserServiceTest {
         assertThat(passwordEncoder.matches("abcd1234!", testUser.getPassword())).isTrue();
         assertThat(testUser.getIsMarketing()).isTrue();
         assertThat(testUser.getIsAlarm()).isTrue();
+    }
+
+    @Test
+    @DisplayName("로그인")
+    void test2() {
+        String email = "testUser@naver.com";
+        String password = "abcd1234!";
+        LoginUserReq loginUserReq = LoginUserReq.builder()
+                .email(email)
+                .password(password)
+                .build();
+
+        JwtTokenRes jwtTokenRes = userService.login(loginUserReq);
+
+        assertThat(tokenProvider.validateToken(jwtTokenRes.getAccessToken())).isTrue();
+        assertThat(tokenProvider.validateToken(jwtTokenRes.getRefreshToken())).isTrue();
+        assertThat(jwtTokenRes.getUserRes().getNickName()).isEqualTo("tester");
     }
 
 


### PR DESCRIPTION
### ✨ 작업 내용

- [x] 유저 서비스 테스트코드 작성
- [x] 유저 컨트롤러 테스트코드 작성

### ✨ 코멘트

- 컨트롤러 테스트에서 사용한 기법
  -  Mocking을 통해 Controller 단위 테스트 시행
  - 통합테스트가 아닌 단위 테스트를 진행할 때는 어노테이션에 주의해야합니다.
  - 이번 테스트에 사용된 UserControllerTest.java 파일에서 사용된 WebMvcTest를 명시해 사용하면, 컨트롤러 레이어의 단위테스트 형태를 갖출 수 있습니다

- Mocking 기법 예시
  - Mocking을 통해 Controller 레이어의 단위테스트가 목적
  - 필요없는 내부동작을 임의로 동작한 것으로 치고 반환
  - Controller에서 필요없는 로직인 UserService안의 로직을 Mocking하여, Controller 레이어에서 사용되는 Request, Response, Valid 등을 테스트할 수 있음

```java

@Slf4j
@WebMvcTest(UserController.class) // WebMvcTest는 컨트롤러 레이어만 테스트하기 위해 스프링의 WebMvc 관련 빈만 로드
@MockBean(JpaMetamodelMappingContext.class) // jpa동작하지않도록
@AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터 제외
@ActiveProfiles("test")
class UserControllerTest {
    ...... 중략
    @Autowired
    private MockMvc mockMvc; //실제 서블릿 컨테이너 없이도 HTTP 요청과 응답을 테스트하기 위해 사용

    @Autowired
    private ObjectMapper objectMapper; // Response 매핑을 위한 객체

    @MockBean
    private UserService userService; // @MockBean을 활용하여 UserService를 Mocking


    private final User mockUser = User.builder()
                .id(UUID.randomUUID())
                .email("mockUser@naver.com")
                .nickname("mockUser")
                .password("abcd1234!")
                .isMarketing(true)
                .isAlarm(true)
                .state(State.ACTIVE)
                .build();
    
    @Test
    @DisplayName("회원가입 성공 response 테스트")
    void testCreateUserSuccess() throws Exception {
    CreateUserReq createUserReq = CreateUserReq.testCreate(); // 임의의 UserReq 생성
    
    /** CreateUserReq 타입에 맞는 객체가 UserService.create에 들어가면 mockUser를 반환하도록
    *    given 메서드는 BDD 스타일 테스트에서 사용되는 Mockito의 메서드
    *    mocking객체(UserService)안의 파라미터에 any(), eq() 두 메서드를 통해 값을 넣어줄 수 있고
    *    any(CreateUserReq.class) 선언 시 CreateUserReq 타입이 userService.create() 안에 들어가야 모킹된 mockUser가 반환된다
    **/
    given(userService.create(any(CreateUserReq.class))).willReturn(mockUser);

    /**
    *  "/users"의 위치로 헤더에 MediaType 타입에 APPLICATION_JSON, body에 createUserReq의 값을 담아 요청
    *  andExpect() 안에서 값이 어떻게 반환되는지 확인 현재 예시에서는 201반환하는지 확인
    **/
    mockMvc.perform(post("/users")
                .contentType(MediaType.APPLICATION_JSON)
                .content(objectMapper.writeValueAsString(createUserReq)))
            .andExpect(status().isCreated());
    ...... 중략
}

```

### ❗구현이슈
- @AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터 제외
- 임의의 시큐리티 필터를 생성했을 시엔, 해당 어노테이션을 넣어줘야 한다.
- 넣어주지 않을 시 실제 시큐리티 필터를 타서 문제 발생

### Git Close

- close #43
