### PR TITLE
feat/60

### DIFF
--- a/src/main/java/com/picnee/travel/api/PostCommentController.java
+++ b/src/main/java/com/picnee/travel/api/PostCommentController.java
@@ -3,6 +3,7 @@ package com.picnee.travel.api;
 import com.picnee.travel.api.in.PostCommentApi;
 import com.picnee.travel.domain.postComment.dto.req.CreatePostCommentReq;
 import com.picnee.travel.domain.postComment.dto.req.UpdatePostCommentReq;
+import com.picnee.travel.domain.postComment.dto.res.GetMyPostCommentRes;
 import com.picnee.travel.domain.postComment.dto.res.GetPostCommentRes;
 import com.picnee.travel.domain.postComment.entity.PostComment;
 import com.picnee.travel.domain.postComment.service.PostCommentService;
@@ -12,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Fetch;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
@@ -77,6 +79,13 @@ public class PostCommentController implements PostCommentApi {
                                                   @AuthenticatedUser AuthenticatedUserReq auth) {
         postCommentService.toggleLike(postId, commentId, auth);
         return ResponseEntity.status(OK).build();
+    }
+
+    @GetMapping("/my-comments")
+    public ResponseEntity<Page<GetMyPostCommentRes>> getMyPostComments(@RequestParam(name = "page", defaultValue = "0") int page,
+                                                                       @AuthenticatedUser AuthenticatedUserReq auth) {
+        Page<GetMyPostCommentRes> res = postCommentService.getMyComments(page, auth);
+        return ResponseEntity.status(OK).body(res);
     }
 }
 

--- a/src/main/java/com/picnee/travel/api/PostController.java
+++ b/src/main/java/com/picnee/travel/api/PostController.java
@@ -64,4 +64,11 @@ public class PostController implements PostApi {
         Page<FindPostRes> posts = postService.findPosts(boardCategory, region, sort, page);
         return ResponseEntity.status(OK).body(posts);
     }
+
+    @GetMapping("/my-posts")
+    public ResponseEntity<Page<FindPostRes>> getMyPosts(@RequestParam(name = "page", defaultValue = "0") int page,
+                                                        @AuthenticatedUser AuthenticatedUserReq auth) {
+        Page<FindPostRes> posts = postService.getMyPosts(auth, page);
+        return ResponseEntity.status(OK).body(posts);
+    }
 }

--- a/src/main/java/com/picnee/travel/api/PostController.java
+++ b/src/main/java/com/picnee/travel/api/PostController.java
@@ -59,8 +59,9 @@ public class PostController implements PostApi {
     @GetMapping
     public ResponseEntity<Page<FindPostRes>> findPosts(@RequestParam(name = "boardCategory", required = false) String boardCategory,
                                                        @RequestParam(name = "region", required = false) String region,
+                                                       @RequestParam(name = "sort", required = false, defaultValue = "new") String sort,
                                                        @RequestParam(name = "page", defaultValue = "0") int page) {
-        Page<FindPostRes> posts = postService.findPosts(boardCategory, region, page);
+        Page<FindPostRes> posts = postService.findPosts(boardCategory, region, sort, page);
         return ResponseEntity.status(OK).body(posts);
     }
 }

--- a/src/main/java/com/picnee/travel/api/in/PostApi.java
+++ b/src/main/java/com/picnee/travel/api/in/PostApi.java
@@ -28,5 +28,5 @@ public interface PostApi {
     public ResponseEntity<FindPostRes> findPost(UUID postId, AuthenticatedUserReq auth);
 
     @Operation(summary = "게시글 전체 조회", description = "게시글을 전체 조회한다.")
-    public ResponseEntity<Page<FindPostRes>> findPosts(String boardCategory, String region, int page);
+    public ResponseEntity<Page<FindPostRes>> findPosts(String boardCategory, String region, String sort, int page);
 }

--- a/src/main/java/com/picnee/travel/api/in/PostApi.java
+++ b/src/main/java/com/picnee/travel/api/in/PostApi.java
@@ -29,4 +29,7 @@ public interface PostApi {
 
     @Operation(summary = "게시글 전체 조회", description = "게시글을 전체 조회한다.")
     public ResponseEntity<Page<FindPostRes>> findPosts(String boardCategory, String region, String sort, int page);
+
+    @Operation(summary = "작성한 게시글 조회", description = "자신이 작성한 게시글만 조회한다.")
+    public ResponseEntity<Page<FindPostRes>> getMyPosts(int page, AuthenticatedUserReq auth);
 }

--- a/src/main/java/com/picnee/travel/api/in/PostCommentApi.java
+++ b/src/main/java/com/picnee/travel/api/in/PostCommentApi.java
@@ -2,11 +2,13 @@ package com.picnee.travel.api.in;
 
 import com.picnee.travel.domain.postComment.dto.req.CreatePostCommentReq;
 import com.picnee.travel.domain.postComment.dto.req.UpdatePostCommentReq;
+import com.picnee.travel.domain.postComment.dto.res.GetMyPostCommentRes;
 import com.picnee.travel.domain.postComment.dto.res.GetPostCommentRes;
 import com.picnee.travel.domain.user.dto.req.AuthenticatedUserReq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.coyote.Response;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
@@ -34,4 +36,7 @@ public interface PostCommentApi {
 
     @Operation(summary = "댓글 좋아요", description = "댓글에 좋아요를 한다.")
     public ResponseEntity<Void> toggleCommentLike(UUID postId, UUID commentId, AuthenticatedUserReq auth);
+
+    @Operation(summary = "작성한 댓글 조회", description = "내가 작성한 댓글을 조회한다.")
+    public ResponseEntity<Page<GetMyPostCommentRes>> getMyPostComments(int page, AuthenticatedUserReq auth);
 }

--- a/src/main/java/com/picnee/travel/domain/post/exception/NotAuthException.java
+++ b/src/main/java/com/picnee/travel/domain/post/exception/NotAuthException.java
@@ -1,0 +1,10 @@
+package com.picnee.travel.domain.post.exception;
+
+import com.picnee.travel.global.exception.BusinessException;
+import com.picnee.travel.global.exception.ErrorCode;
+
+public class NotAuthException extends BusinessException {
+    public NotAuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryCustom.java
@@ -9,5 +9,5 @@ import java.util.UUID;
 public interface PostRepositoryCustom {
     Page<Post> findByPosts(String boardCategory, String region, String sort, Pageable pageable);
 
-    Page<Post> findMyPosts(UUID userId, Pageable pageable);
+    Page<Post> getMyPosts(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryCustom.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostRepositoryCustom {
-    Page<Post> findByPosts(String boardCategory, String region, Pageable pageable);
+    Page<Post> findByPosts(String boardCategory, String region, String sort, Pageable pageable);
 }

--- a/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryCustom.java
@@ -4,6 +4,10 @@ import com.picnee.travel.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.UUID;
+
 public interface PostRepositoryCustom {
     Page<Post> findByPosts(String boardCategory, String region, String sort, Pageable pageable);
+
+    Page<Post> findMyPosts(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryImpl.java
@@ -40,14 +40,13 @@ public class PostRepositoryImpl implements PostRepositoryCustom{
             builder.and(post.board.region.eq(Region.fromString(region)));
         }
 
-        log.info("sort = {} ", sort);
         JPAQuery<Post> query = jpaQueryFactory
                 .selectFrom(post)
                 .where(builder);
 
         switch (sort) {
             case "new" -> query.orderBy(post.createdAt.desc());
-            case "viewed" -> query.orderBy(post.viewed.desc(), post.createdAt.desc());
+            case "popular" -> query.orderBy(post.viewed.desc(), post.createdAt.desc());
             case "comment" -> query.orderBy(post.comments.size().desc(), post.createdAt.desc());
             default -> query.orderBy(post.createdAt.desc());
         }

--- a/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/picnee/travel/domain/post/repository/PostRepositoryImpl.java
@@ -68,7 +68,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom{
     }
 
     @Override
-    public Page<Post> findMyPosts(UUID userId, Pageable pageable) {
+    public Page<Post> getMyPosts(UUID userId, Pageable pageable) {
         QPost post = QPost.post;
 
         JPAQuery<Post> query = jpaQueryFactory

--- a/src/main/java/com/picnee/travel/domain/post/service/PostService.java
+++ b/src/main/java/com/picnee/travel/domain/post/service/PostService.java
@@ -110,9 +110,9 @@ public class PostService {
     /**
      * 문의 글 전체 조회
      */
-    public Page<FindPostRes> findPosts(String boardCategory, String region, int page) {
+    public Page<FindPostRes> findPosts(String boardCategory, String region, String sort, int page) {
         Pageable pageable = PageRequest.of(page, 10);
-        Page<Post> posts = postRepository.findByPosts(boardCategory, region, pageable);
+        Page<Post> posts = postRepository.findByPosts(boardCategory, region, sort, pageable);
 
         return FindPostRes.paging(posts);
     }

--- a/src/main/java/com/picnee/travel/domain/post/service/PostService.java
+++ b/src/main/java/com/picnee/travel/domain/post/service/PostService.java
@@ -6,6 +6,7 @@ import com.picnee.travel.domain.post.dto.req.CreatePostReq;
 import com.picnee.travel.domain.post.dto.req.ModifyPostReq;
 import com.picnee.travel.domain.post.dto.res.FindPostRes;
 import com.picnee.travel.domain.post.entity.Post;
+import com.picnee.travel.domain.post.exception.NotAuthException;
 import com.picnee.travel.domain.post.exception.NotFoundPostException;
 import com.picnee.travel.domain.post.exception.NotPostAuthorException;
 import com.picnee.travel.domain.post.repository.PostRepository;
@@ -115,6 +116,22 @@ public class PostService {
         Page<Post> posts = postRepository.findByPosts(boardCategory, region, sort, pageable);
 
         return FindPostRes.paging(posts);
+    }
+
+    /**
+     * 내가 작성한 게시글 조회
+     */
+    public Page<FindPostRes> getMyPosts(AuthenticatedUserReq auth, int page) {
+        if(!isUserAuthenticated(auth)) {
+            throw new NotAuthException(NOT_AUTH_EXCEPTION);
+        }
+
+        User user = userService.findByEmail(auth.getEmail());
+        Pageable pageable = PageRequest.of(page, 10);
+
+        Page<Post> myPosts = postRepository.findMyPosts(user.getId(), pageable);
+
+        return FindPostRes.paging(myPosts);
     }
 
     /**

--- a/src/main/java/com/picnee/travel/domain/post/service/PostService.java
+++ b/src/main/java/com/picnee/travel/domain/post/service/PostService.java
@@ -20,13 +20,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
 import static com.picnee.travel.global.exception.ErrorCode.*;
-import static org.springframework.transaction.annotation.Propagation.*;
 
 @Slf4j
 @Service
@@ -129,7 +127,7 @@ public class PostService {
         User user = userService.findByEmail(auth.getEmail());
         Pageable pageable = PageRequest.of(page, 10);
 
-        Page<Post> myPosts = postRepository.findMyPosts(user.getId(), pageable);
+        Page<Post> myPosts = postRepository.getMyPosts(user.getId(), pageable);
 
         return FindPostRes.paging(myPosts);
     }

--- a/src/main/java/com/picnee/travel/domain/postComment/dto/res/GetChildrenCommentRes.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/dto/res/GetChildrenCommentRes.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Getter
@@ -14,6 +15,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class GetChildrenCommentRes {
 
+    private UUID commentId;
     private String content;
     private Long likes;
     private UserRes userRes;
@@ -22,6 +24,7 @@ public class GetChildrenCommentRes {
     public static List<GetChildrenCommentRes> from(List<PostComment> replies) {
         return replies.stream()
                 .map(reply -> GetChildrenCommentRes.builder()
+                        .commentId(reply.getId())
                         .content(reply.getContent())
                         .likes(reply.getLikes())
                         .userRes(UserRes.from(reply.getUser()))

--- a/src/main/java/com/picnee/travel/domain/postComment/dto/res/GetMyPostCommentRes.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/dto/res/GetMyPostCommentRes.java
@@ -1,0 +1,51 @@
+package com.picnee.travel.domain.postComment.dto.res;
+
+import com.picnee.travel.domain.post.dto.res.FindPostRes;
+import com.picnee.travel.domain.postComment.entity.PostComment;
+import com.picnee.travel.domain.user.dto.res.UserRes;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+public class GetMyPostCommentRes {
+
+    private UUID commentId;
+    private UUID postId;
+    private String content;
+    private Long likes;
+    private UserRes userRes;
+    private LocalDateTime createdAt;
+
+    private static GetMyPostCommentRes from(PostComment postComment) {
+        return GetMyPostCommentRes.builder()
+                .commentId(postComment.getId())
+                .postId(postComment.getPost().getId())
+                .content(postComment.getContent())
+                .likes(postComment.getLikes())
+                .userRes(UserRes.from(postComment.getUser()))
+                .createdAt(postComment.getCreatedAt())
+                .build();
+    }
+
+    public static Page<GetMyPostCommentRes> paging(Page<PostComment> myComments) {
+        List<GetMyPostCommentRes> contents = myComments.getContent().stream()
+                .map(GetMyPostCommentRes::from)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(contents, myComments.getPageable(), myComments.getTotalElements());
+    }
+}

--- a/src/main/java/com/picnee/travel/domain/postComment/entity/PostComment.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/entity/PostComment.java
@@ -7,6 +7,7 @@ import com.picnee.travel.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UuidGenerator;
@@ -24,6 +25,7 @@ import static org.hibernate.annotations.UuidGenerator.Style.RANDOM;
 @Entity
 @Table(name = "post_comment")
 @SuperBuilder
+@DynamicUpdate
 @AllArgsConstructor
 @SQLRestriction("is_deleted = false")
 @NoArgsConstructor(access = PROTECTED)

--- a/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepository.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepository.java
@@ -4,8 +4,10 @@ import com.picnee.travel.domain.postComment.entity.PostComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface PostCommentRepository extends JpaRepository<PostComment, UUID>, PostCommentRepositoryCustom{
+
 }

--- a/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryCustom.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryCustom.java
@@ -5,7 +5,10 @@ import com.picnee.travel.domain.postComment.entity.PostComment;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface PostCommentRepositoryCustom {
     List<PostComment> findByCommentsOfPost(Post post);
+
+    List<PostComment> findChildrenByParentId(UUID commentId);
 }

--- a/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryCustom.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryCustom.java
@@ -2,7 +2,9 @@ package com.picnee.travel.domain.postComment.repository;
 
 import com.picnee.travel.domain.post.entity.Post;
 import com.picnee.travel.domain.postComment.entity.PostComment;
+import com.picnee.travel.domain.user.entity.User;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,4 +13,6 @@ public interface PostCommentRepositoryCustom {
     List<PostComment> findByCommentsOfPost(Post post);
 
     List<PostComment> findChildrenByParentId(UUID commentId);
+
+    Page<PostComment> getMyComments(Pageable pageable, UUID userId);
 }

--- a/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
@@ -1,13 +1,20 @@
 package com.picnee.travel.domain.postComment.repository;
 
 import com.picnee.travel.domain.post.entity.Post;
+import com.picnee.travel.domain.post.entity.QPost;
 import com.picnee.travel.domain.postComment.entity.PostComment;
 import com.picnee.travel.domain.postComment.entity.QPostComment;
+import com.picnee.travel.domain.user.entity.User;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -39,5 +46,31 @@ public class PostCommentRepositoryImpl implements PostCommentRepositoryCustom{
                 .where(postComment.commentParent.id.eq(commentId)
                         .and(postComment.isDeleted.isFalse()))
                 .fetch();
+    }
+
+    @Override
+    public Page<PostComment> getMyComments(Pageable pageable, UUID userId) {
+        QPostComment postComment = QPostComment.postComment;
+
+        JPAQuery<PostComment> query = jpaQueryFactory
+                .selectFrom(postComment)
+                .where(postComment.isDeleted.isFalse(),
+                        postComment.user.id.eq(userId))
+                .orderBy(postComment.createdAt.desc());
+
+        List<PostComment> result = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = Optional.ofNullable(jpaQueryFactory
+                        .select(postComment.count())
+                        .from(postComment)
+                        .where(postComment.isDeleted.isFalse(),
+                                postComment.user.id.eq(userId)) // 동적 조건 동일하게 사용
+                        .fetchOne())
+                .orElse(0L);
+
+        return new PageImpl<>(result, pageable, total);
     }
 }

--- a/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,6 +27,17 @@ public class PostCommentRepositoryImpl implements PostCommentRepositoryCustom{
                         .and(postComment.isDeleted.isFalse())
                         .and(postComment.commentParent.isNull()))
                 .orderBy(postComment.createdAt.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<PostComment> findChildrenByParentId(UUID commentId) {
+        QPostComment postComment = QPostComment.postComment;
+
+        return jpaQueryFactory
+                .selectFrom(postComment)
+                .where(postComment.commentParent.id.eq(commentId)
+                        .and(postComment.isDeleted.isFalse()))
                 .fetch();
     }
 }

--- a/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
@@ -1,10 +1,13 @@
 package com.picnee.travel.domain.postComment.service;
 
 import com.picnee.travel.domain.notification.dto.event.PostCommentEvent;
+import com.picnee.travel.domain.post.dto.res.FindPostRes;
 import com.picnee.travel.domain.post.entity.Post;
+import com.picnee.travel.domain.post.exception.NotAuthException;
 import com.picnee.travel.domain.post.service.PostService;
 import com.picnee.travel.domain.postComment.dto.req.CreatePostCommentReq;
 import com.picnee.travel.domain.postComment.dto.req.UpdatePostCommentReq;
+import com.picnee.travel.domain.postComment.dto.res.GetMyPostCommentRes;
 import com.picnee.travel.domain.postComment.dto.res.GetPostCommentRes;
 import com.picnee.travel.domain.postComment.entity.PostComment;
 import com.picnee.travel.domain.postComment.exception.NotFoundCommentException;
@@ -18,6 +21,9 @@ import com.picnee.travel.domain.userPostCommet.service.UserPostCommentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -126,6 +132,21 @@ public class PostCommentService {
         }
 
         postComment.deleteLike();
+    }
+
+    /**
+     * 내가 작성한 댓글 확인
+     */
+    public Page<GetMyPostCommentRes> getMyComments(int page, AuthenticatedUserReq auth) {
+        if(isUserAuthenticated(auth)) {
+            throw new NotAuthException(NOT_AUTH_EXCEPTION);
+        }
+
+        User user = userService.findByEmail(auth.getEmail());
+        Pageable pageable = PageRequest.of(page, 10);
+
+        Page<PostComment> myComments = postCommentRepository.getMyComments(pageable, user.getId());
+        return GetMyPostCommentRes.paging(myComments);
     }
 
 

--- a/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
@@ -80,7 +80,10 @@ public class PostCommentService {
 
         validOwner(postComment, user);
 
+        // 부모 댓글과 자식댓글 삭제
+        List<PostComment> childComments = postCommentRepository.findChildrenByParentId(postComment.getId());
         postComment.softDelete();
+        childComments.forEach(PostComment::softDelete);
     }
 
     /**

--- a/src/main/java/com/picnee/travel/global/exception/ErrorCode.java
+++ b/src/main/java/com/picnee/travel/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     NOT_NOTIFICATION_RECIPIENT_EXCEPTION(UNAUTHORIZED, "G007", "알림 수신자가 아닙니다. 본인의 알림만 읽을 수 있습니다."),
     NOT_PROVIDE_OAUTH_EXCEPTION(UNAUTHORIZED, "G008", "올바르지 않은 소셜 로그인입니다."),
     NOT_PROVIDE_COMMENT_LIKE_EXCEPTION(UNAUTHORIZED, "G009", "댓글 좋아요는 로그인시 가능합니다."),
+    NOT_AUTH_EXCEPTION(UNAUTHORIZED, "G010", "로그인한 유저만 접근가능합니다."),
 
     /**
      * 403

--- a/src/test/java/com/picnee/travel/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/picnee/travel/domain/post/service/PostServiceTest.java
@@ -98,7 +98,7 @@ class PostServiceTest {
     @DisplayName("자유 토크 게시글 삭제 성공")
     void test4() {
         postService.delete(post.getId(), user);
-        Page<FindPostRes> posts = postService.findPosts(null, null, null,0);
+        Page<FindPostRes> posts = postService.findPosts(null, null, "new",0);
         assertThat(posts.getTotalElements()).isEqualTo(0L);
     }
 
@@ -108,7 +108,7 @@ class PostServiceTest {
         assertThatThrownBy(() -> postService.delete(post.getId(), anotherUser))
                 .isInstanceOf(NotPostAuthorException.class);
 
-        Page<FindPostRes> posts = postService.findPosts(null, null, null,0);
+        Page<FindPostRes> posts = postService.findPosts(null, null, "new",0);
         assertThat(posts.getTotalElements()).isEqualTo(1L);
     }
 
@@ -151,7 +151,7 @@ class PostServiceTest {
         }
 
         // 5 + 1 = 6개의 게시글이 나와야 한다.
-        Page<FindPostRes> posts = postService.findPosts(null, null, null,0);
+        Page<FindPostRes> posts = postService.findPosts(null, null, "new",0);
 
         assertThat(posts.getTotalElements()).isEqualTo(6L);
     }
@@ -170,7 +170,7 @@ class PostServiceTest {
             postService.create(postReq, user);
         }
 
-        Page<FindPostRes> posts = postService.findPosts("숙박", null, null,0);
+        Page<FindPostRes> posts = postService.findPosts("숙박", null, "new",0);
 
         assertThat(posts.getTotalElements()).isEqualTo(3L);
     }
@@ -188,7 +188,7 @@ class PostServiceTest {
 
             postService.create(postReq, user);
         }
-        Page<FindPostRes> posts = postService.findPosts("숙박", "오사카", null,0);
+        Page<FindPostRes> posts = postService.findPosts("숙박", "오사카", "new",0);
 
         assertThat(posts.getTotalElements()).isEqualTo(2L);
     }
@@ -224,7 +224,7 @@ class PostServiceTest {
         postService.create(postReq3, user);
 
         // 규슈, 숙박은 2개이기 때문에 2개가 나와야 한다.
-        Page<FindPostRes> posts = postService.findPosts("숙박", "오사카", null,0);
+        Page<FindPostRes> posts = postService.findPosts("숙박", "오사카", "new",0);
 
         assertThat(posts.getTotalElements()).isEqualTo(2L);
     }

--- a/src/test/java/com/picnee/travel/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/picnee/travel/domain/post/service/PostServiceTest.java
@@ -98,7 +98,7 @@ class PostServiceTest {
     @DisplayName("자유 토크 게시글 삭제 성공")
     void test4() {
         postService.delete(post.getId(), user);
-        Page<FindPostRes> posts = postService.findPosts(null, null, 0);
+        Page<FindPostRes> posts = postService.findPosts(null, null, null,0);
         assertThat(posts.getTotalElements()).isEqualTo(0L);
     }
 
@@ -108,7 +108,7 @@ class PostServiceTest {
         assertThatThrownBy(() -> postService.delete(post.getId(), anotherUser))
                 .isInstanceOf(NotPostAuthorException.class);
 
-        Page<FindPostRes> posts = postService.findPosts(null, null, 0);
+        Page<FindPostRes> posts = postService.findPosts(null, null, null,0);
         assertThat(posts.getTotalElements()).isEqualTo(1L);
     }
 
@@ -151,7 +151,7 @@ class PostServiceTest {
         }
 
         // 5 + 1 = 6개의 게시글이 나와야 한다.
-        Page<FindPostRes> posts = postService.findPosts(null, null, 0);
+        Page<FindPostRes> posts = postService.findPosts(null, null, null,0);
 
         assertThat(posts.getTotalElements()).isEqualTo(6L);
     }
@@ -170,7 +170,7 @@ class PostServiceTest {
             postService.create(postReq, user);
         }
 
-        Page<FindPostRes> posts = postService.findPosts("숙박", null, 0);
+        Page<FindPostRes> posts = postService.findPosts("숙박", null, null,0);
 
         assertThat(posts.getTotalElements()).isEqualTo(3L);
     }
@@ -188,7 +188,7 @@ class PostServiceTest {
 
             postService.create(postReq, user);
         }
-        Page<FindPostRes> posts = postService.findPosts("숙박", "오사카", 0);
+        Page<FindPostRes> posts = postService.findPosts("숙박", "오사카", null,0);
 
         assertThat(posts.getTotalElements()).isEqualTo(2L);
     }
@@ -224,7 +224,7 @@ class PostServiceTest {
         postService.create(postReq3, user);
 
         // 규슈, 숙박은 2개이기 때문에 2개가 나와야 한다.
-        Page<FindPostRes> posts = postService.findPosts("숙박", "오사카", 0);
+        Page<FindPostRes> posts = postService.findPosts("숙박", "오사카", null,0);
 
         assertThat(posts.getTotalElements()).isEqualTo(2L);
     }


### PR DESCRIPTION
### ✨ 작업 내용

- [x] 부모 댓글 삭제 시 자식 댓글 softDelete
- [x] 게시글 필터링
- [x] 내가 작성한 게시글, 댓글 엔드 포인트 생성

### ✨ 코멘트

- 리팩터링 해야할 부분

현재 자식 댓글을 삭제할 때 List를 foreach로 순회하면서 제거해주고 있는데 이럴 경우 대댓글이 100개면 update 구문이 100개가 나가는 문제가 있음

  -  해결 방향 ( 다음 태스크로 뺴서 진행하도록 하겠습니다.)
  ---
  ```
UPDATE  post_comment pc
   SET is_deleted = TRUE
 WHERE post_comment_id IN (
               SELECT *
                  FROM post_comment pc 
               WHERE post_comment_id IN (
                              SELECT pc.post_comment_id
                                FROM post_comment pc
                             WHERE pc.post_comment_id = '2e7c93ba-1410-47e5-9d87-e4849c3c3c4c'
														
                              UNION ALL

                             SELECT child.post_comment_id
                                FROM post_comment child
                             WHERE child.post_comment_parent_id = '2e7c93ba-1410-47e5-9d87-e4849c3c3c4c'));
  ```

이런식으로 IN 절로 한번에 처리해보도록 하겠습니다.
`queryDSL에서는 WITH절이 불가능하다고 합니다. 물론 UNION ALL도 없긴한데 일괄적으로 처리하도록 하겠습니다.`

issue 해결 : #71 

### Git Close

- close #60  
