### PR TITLE
feat/69

### DIFF
--- a/src/main/java/com/picnee/travel/domain/postComment/entity/PostComment.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/entity/PostComment.java
@@ -62,10 +62,6 @@ public class PostComment extends SoftDeleteBaseEntity {
         this.content = dto.getContent() == null ? this.content : dto.getContent();
     }
 
-    public void softDelete() {
-        super.delete();
-    }
-
     /**
      * 좋아요 추가
      */

--- a/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryCustom.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryCustom.java
@@ -2,7 +2,7 @@ package com.picnee.travel.domain.postComment.repository;
 
 import com.picnee.travel.domain.post.entity.Post;
 import com.picnee.travel.domain.postComment.entity.PostComment;
-import com.picnee.travel.domain.user.entity.User;
+import com.querydsl.jpa.JPQLQuery;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,7 +12,7 @@ import java.util.UUID;
 public interface PostCommentRepositoryCustom {
     List<PostComment> findByCommentsOfPost(Post post);
 
-    List<PostComment> findChildrenByParentId(UUID commentId);
+    void findChildrenByParentId(UUID commentId);
 
     Page<PostComment> getMyComments(Pageable pageable, UUID userId);
 }

--- a/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/repository/PostCommentRepositoryImpl.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 public class PostCommentRepositoryImpl implements PostCommentRepositoryCustom{
 
     private final JPAQueryFactory jpaQueryFactory;
-    private final EntityManager entityManager;
 
     @Override
     public List<PostComment> findByCommentsOfPost(Post post) {

--- a/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
+++ b/src/main/java/com/picnee/travel/domain/postComment/service/PostCommentService.java
@@ -87,9 +87,7 @@ public class PostCommentService {
         validOwner(postComment, user);
 
         // 부모 댓글과 자식댓글 삭제
-        List<PostComment> childComments = postCommentRepository.findChildrenByParentId(postComment.getId());
-        postComment.softDelete();
-        childComments.forEach(PostComment::softDelete);
+        postCommentRepository.findChildrenByParentId(postComment.getId());
     }
 
     /**


### PR DESCRIPTION
### ✨ 작업 내용

- [x] 댓글 삭제 시 자식 댓글 IN 쿼리로 update

### ✨ 코멘트

- 댓글 삭제 시 자식 댓글 in 절로 한 쿼리로 처리

```
    update
        post_comment pc1_0 
    set
        is_deleted=true 
    where
        pc1_0.post_comment_id in ('0a8ef82c-13c3-4702-839f-e7e951ef712c', '2c5b0367-8eea-4eb8-a7b3-722dcf15a210', '635073c1-ec8a-49cb-966d-3bd4e9c86632', '718b33c6-cc6c-4b2b-aac8-9323e81aaf0f', 'cec5b51b-e85d-408b-a77c-a3a8c04b94af', 'ee8681e8-4ca4-41f2-a907-c2d54a8f74ec', 'fd276b5d-3f78-4984-9f78-0a515cf6bb99') 
        and (
            pc1_0.is_deleted = 0
        )
```

### Git Close

- close #69 
